### PR TITLE
Inspection fixes

### DIFF
--- a/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		FA0B20F12A7DA20200EC91D3 /* AnyViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0B20F02A7DA20200EC91D3 /* AnyViewPreview.swift */; };
 		FA0D85432A72A5BD002A28ED /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = FA0D85422A72A5BD002A28ED /* SnapshottingTests */; };
 		FA1671C32A5367A800A42DB0 /* DemoAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1671C22A5367A800A42DB0 /* DemoAppApp.swift */; };
 		FA1671C52A5367A800A42DB0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1671C42A5367A800A42DB0 /* ContentView.swift */; };
@@ -81,6 +82,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		FA0B20F02A7DA20200EC91D3 /* AnyViewPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyViewPreview.swift; sourceTree = "<group>"; };
 		FA1671BF2A5367A800A42DB0 /* DemoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DemoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA1671C22A5367A800A42DB0 /* DemoAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppApp.swift; sourceTree = "<group>"; };
 		FA1671C42A5367A800A42DB0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -227,6 +229,7 @@
 				FAD52BF32A7B5EEA001F1832 /* RideDetailView.swift */,
 				FAD52BF52A7B5EEA001F1832 /* RideOptionsView.swift */,
 				FAD52BF42A7B5EEA001F1832 /* RideShareButton.swift */,
+				FA0B20F02A7DA20200EC91D3 /* AnyViewPreview.swift */,
 			);
 			path = TestViews;
 			sourceTree = "<group>";
@@ -387,6 +390,7 @@
 				FAD52BF82A7B5EEA001F1832 /* RideDetailView.swift in Sources */,
 				FA1671C32A5367A800A42DB0 /* DemoAppApp.swift in Sources */,
 				FAD52BFA2A7B5EEA001F1832 /* RideOptionsView.swift in Sources */,
+				FA0B20F12A7DA20200EC91D3 /* AnyViewPreview.swift in Sources */,
 				FAD52BF72A7B5EEA001F1832 /* CodeEntryView.swift in Sources */,
 				FAD52BF62A7B5EEA001F1832 /* ExpandingView.swift in Sources */,
 				FAD52BF92A7B5EEA001F1832 /* RideShareButton.swift in Sources */,

--- a/DemoApp/DemoApp/TestViews/AnyViewPreview.swift
+++ b/DemoApp/DemoApp/TestViews/AnyViewPreview.swift
@@ -1,0 +1,20 @@
+//
+//  AnyViewPreview.swift
+//  DemoApp
+//
+//  Created by Noah Martin on 8/4/23.
+//
+
+import Foundation
+import SwiftUI
+
+struct AnyView_Previews: PreviewProvider {
+  static var previews: some View {
+    AnyView(
+      Group {
+        Text("Hello")
+        Text("World")
+      })
+    .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
+  }
+}

--- a/DemoApp/DemoApp/TestViews/RideDetailView.swift
+++ b/DemoApp/DemoApp/TestViews/RideDetailView.swift
@@ -129,6 +129,7 @@ struct RideDetailView_Previews: PreviewProvider {
             .environment(\.sizeCategory, .accessibilityExtraExtraLarge)
             .previewLayout(.sizeThatFits)
         }
+        .environment(\.layoutDirection, .rightToLeft)
     }
 }
 

--- a/DemoApp/DemoApp/TestViews/RideOptionsView.swift
+++ b/DemoApp/DemoApp/TestViews/RideOptionsView.swift
@@ -19,22 +19,22 @@ struct RideOptionView: View {
                     .font(.headline)
 
                 Text(description)
-                    .foregroundColor(.gray)
+                .foregroundColor(Color(uiColor: UIColor.systemGray))
                     .font(.subheadline)
                     .lineLimit(2)
 
                 Text("$\(price, specifier: "%.2f")")
                     .font(.headline)
-                    .foregroundColor(.blue)
+                    .foregroundColor(Color(uiColor: UIColor.systemBlue))
             }
 
             Spacer()
 
             Image(systemName: "chevron.right")
-                .foregroundColor(.gray)
+            .foregroundColor(Color(uiColor: UIColor.systemGray))
         }
         .padding()
-        .background(Color.white)
+        .background(Color(uiColor: UIColor.systemBackground))
         .cornerRadius(12)
         .shadow(color: .gray, radius: 3, x: 0, y: 2)
     }

--- a/Sources/SnapshotPreviewsCore/AnyViewModifier.swift
+++ b/Sources/SnapshotPreviewsCore/AnyViewModifier.swift
@@ -1,0 +1,22 @@
+//
+//  AnyViewModifier.swift
+//  
+//
+//  Created by Noah Martin on 8/4/23.
+//
+
+import SwiftUI
+
+public struct AnyViewModifier: ViewModifier {
+  public func body(content: Content) -> some View {
+    modifier(content)
+  }
+
+  public init(modifier: some ViewModifier) {
+    self.viewModifier = modifier
+    self.modifier = { AnyView($0.modifier(modifier)) }
+  }
+
+  let viewModifier: any ViewModifier
+  private let modifier: (Content) -> AnyView
+}

--- a/Sources/SnapshotPreviewsCore/SnapshotPreviewsCore.swift
+++ b/Sources/SnapshotPreviewsCore/SnapshotPreviewsCore.swift
@@ -7,13 +7,18 @@ public struct Preview: Identifiable {
     displayName = preview.displayName
     device = preview.device
     layout = preview.layout
-    _colorScheme = {
-      let v = ViewInspection.children(of: provider.previews)[preview.id]
-      return ViewInspection.preferredColorScheme(of: v)
+    let _view = {
+      let (v, modifiers) = ViewInspection.children(of: provider.previews)[preview.id]
+      var result = AnyView(v)
+      for modifier in modifiers.reversed() {
+        result = AnyView(result.modifier(modifier))
+      }
+      return result
     }
-    _view = {
-      let v = ViewInspection.children(of: provider.previews)[preview.id]
-      return AnyView(v)
+    self._view = _view
+    _colorScheme = {
+      let v = _view()
+      return ViewInspection.preferredColorScheme(of: v)
     }
   }
 


### PR DESCRIPTION
This supports previews that use modifiers on Groups/ForEach that wrap multiple previews. It also supports wrapping a `Group` in an `AnyView`. For example:

```
AnyView(
  Group {
    Text("Hello")
    Text("World")
  })
.environment(\.sizeCategory, .accessibilityExtraExtraLarge)
```

Would have two previews both using the larger font size. Previously this would crash when generating snapshots.