### PR TITLE
Fix dark mode colors

### DIFF
--- a/Sources/PreviewGallery/PreviewCell.swift
+++ b/Sources/PreviewGallery/PreviewCell.swift
@@ -19,11 +19,11 @@ struct PreviewCell: View {
     VStack {
       try! preview.view()
         .padding(.vertical, 8)
-        .border(colorScheme == .light ? Color.slate100 : Color.black)
+        .border(Color.dynamicBackground)
         .background {
           Checkerboard()
             .foregroundStyle(Color.lightChecker)
-            .background(colorScheme == .light ? Color.slate100 : Color.black)
+            .background(Color.dynamicBackground)
         }
         .preferredColorScheme(nil)
         .colorScheme(try! preview.colorScheme() ?? colorScheme)
@@ -35,4 +35,13 @@ struct PreviewCell: View {
 private extension Color {
   static let lightChecker = Color(#colorLiteral(red: 0.7333333333, green: 0.7333333333, blue: 0.7333333333, alpha: 0.18))
   static let slate100 = Color(#colorLiteral(red: 0.9450980392, green: 0.9607843137, blue: 0.9764705882, alpha: 1))
+
+  static let dynamicBackground = {
+    Color(UIColor { traitCollection in
+      if traitCollection.userInterfaceStyle == .dark {
+        return UIColor(Color.black)
+      }
+      return UIColor(Color.slate100)
+    })
+  }()
 }


### PR DESCRIPTION
The checkerboard background wasn't working in dark mode because it was checking the parent view color scheme in the if statement. Switch to using a dynamic color rather than doing this check ourselves so it always uses the correct subviews color scheme, this is the same behavior from before https://github.com/EmergeTools/SnapshotPreviews-iOS/pull/41