### PR TITLE
Tweak default test plan demo app

### DIFF
--- a/DemoApp/DemoApp.xctestplan
+++ b/DemoApp/DemoApp.xctestplan
@@ -13,7 +13,6 @@
   },
   "testTargets" : [
     {
-      "parallelizable" : true,
       "skippedTests" : [
         "AccessibilityPreviewTest"
       ],

--- a/DemoApp/DemoApp.xctestplan
+++ b/DemoApp/DemoApp.xctestplan
@@ -13,6 +13,9 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "AccessibilityPreviewTest"
+      ],
       "target" : {
         "containerPath" : "container:DemoApp.xcodeproj",
         "identifier" : "FAC167E62A5F41C500D79C23",

--- a/DemoApp/DemoApp.xctestplan
+++ b/DemoApp/DemoApp.xctestplan
@@ -13,6 +13,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "skippedTests" : [
         "AccessibilityPreviewTest"
       ],


### PR DESCRIPTION
`DemoAppAccessibilityPreviewTest` is all that we want to run. We don't want `AccessibilityPreviewTest` to separately also run.

also with parallelization off , basic things like specifying which snapshot previews to actually select don't appear to work