### PR TITLE
kick off updateScrollViewHeight after layout pass completes

### DIFF
--- a/Sources/SnapshotPreviewsCore/ExpandingViewController.swift
+++ b/Sources/SnapshotPreviewsCore/ExpandingViewController.swift
@@ -78,7 +78,11 @@ public final class ExpandingViewController: UIHostingController<EmergeModifierVi
 
   public override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    self.updateScrollViewHeight()
+
+    // Kick off in next run loop cycle to let the layout pass complete first
+    DispatchQueue.main.async {
+      self.updateScrollViewHeight()
+    }
   }
 
   public func updateScrollViewHeight() {


### PR DESCRIPTION
We either do this or call `layoutIfNeeded` at the top of the `updateScrollViewHeight` method in order to ensure that the expansion logic doesn't have a race condition with the layout pass