### PR TITLE
feat(snapshots): Add CI image export via SNAPSHOTS_EXPORT_DIR env var (EME-931)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,9 @@ let package = Package(
         .testTarget(
             name: "SnapshotPreviewsTests",
             dependencies: ["SnapshotPreviewsCore"]),
+        .testTarget(
+            name: "SnapshottingTestsTests",
+            dependencies: ["SnapshottingTests", "SnapshotPreviewsCore"]),
     ],
     cxxLanguageStandard: .cxx11
 )

--- a/Sources/SnapshotPreviewsCore/View+Snapshot.swift
+++ b/Sources/SnapshotPreviewsCore/View+Snapshot.swift
@@ -117,7 +117,8 @@ extension View {
     window: UIWindow,
     rootVC: UIViewController,
     targetView: UIView,
-    maxSize: Double = 1_000_000) -> Result<UIImage, RenderingError>
+    maxSize: Double = 1_000_000,
+    maxTotalPixels: Double = 40_000_000) -> Result<UIImage, RenderingError>
   {
     if renderingMode == EmergeRenderingMode.window {
       let renderer = UIGraphicsImageRenderer(size: window.bounds.size)
@@ -155,7 +156,9 @@ extension View {
         success = rootVC.view.render(size: targetSize, mode: renderingMode, context: ctx)
       }
     }
-    if targetSize.height > maxSize || targetSize.width > maxSize {
+    let scale = Double(UIScreen.main.scale)
+    let totalPixels = Double(targetSize.width) * scale * Double(targetSize.height) * scale
+    if targetSize.height > maxSize || targetSize.width > maxSize || totalPixels > maxTotalPixels {
       return .failure(RenderingError.maxSize(targetSize))
     }
     let renderer = UIGraphicsImageRenderer(size: targetSize)

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -67,15 +67,11 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
   private let stateLock = NSLock()
   private var hasDrained = false
 
-  // MARK: - Shared Instance
+  // MARK: - Factory
 
-  @MainActor private static var _shared: SnapshotCIExportCoordinator?
-
-  @MainActor static func sharedIfEnabled(
+  static func createFromEnvironment(
     environment: [String: String] = ProcessInfo.processInfo.environment
   ) -> SnapshotCIExportCoordinator? {
-    if let _shared { return _shared }
-
     guard let exportDir = environment[envKey] else {
       return nil
     }
@@ -100,17 +96,8 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
     }
 
     let coordinator = Self(exportDirectoryURL: url)
-    _shared = coordinator
     XCTestObservationCenter.shared.addTestObserver(coordinator)
     return coordinator
-  }
-
-  /// Resets shared state. Exposed for testing only.
-  @MainActor static func resetShared() {
-    if let shared = _shared {
-      XCTestObservationCenter.shared.removeTestObserver(shared)
-    }
-    _shared = nil
   }
 
   // MARK: - Init

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -250,8 +250,6 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
     hasDrained = true
     stateLock.unlock()
 
-    guard fileManager.fileExists(atPath: exportDirectoryURL.path) else { return }
-
     let semaphore = DispatchSemaphore(value: 0)
     writeQueue.addBarrierBlock {
       semaphore.signal()

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -161,16 +161,20 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
 
   // MARK: - Export
 
-  private static func canonicalGroup(for context: SnapshotContext) -> String {
-    if let fileId = context.fileId, !fileId.isEmpty {
+  static func canonicalGroup(
+    fileId: String?,
+    typeDisplayName: String,
+    typeName: String
+  ) -> String {
+    if let fileId, !fileId.isEmpty {
       return fileId
     }
 
-    if !context.typeDisplayName.isEmpty {
-      return context.typeDisplayName
+    if !typeDisplayName.isEmpty {
+      return typeDisplayName
     }
 
-    return context.typeName
+    return typeName
   }
 
   private static func canonicalDisplayName(for context: SnapshotContext) -> String {
@@ -198,7 +202,11 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
     let jsonFileName = "\(sanitizedName).json"
 
     let displayName = Self.canonicalDisplayName(for: context)
-    let group = Self.canonicalGroup(for: context)
+    let group = Self.canonicalGroup(
+      fileId: context.fileId,
+      typeDisplayName: context.typeDisplayName,
+      typeName: context.typeName
+    )
     let exportDir = exportDirectoryURL
     
     guard case .success(let image) = result.image else { return }

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -197,9 +197,8 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
     result: SnapshotResult,
     context: SnapshotContext
   ) {
-    let sanitizedName = Self.sanitize(context.baseFileName)
-    let pngFileName = "\(sanitizedName).png"
-    let jsonFileName = "\(sanitizedName).json"
+    let pngFileName = "\(context.baseFileName).png"
+    let jsonFileName = "\(context.baseFileName).json"
 
     let displayName = Self.canonicalDisplayName(for: context)
     let group = Self.canonicalGroup(
@@ -226,7 +225,7 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
 
       let sidecar = SnapshotCIExportSidecar(
         context: context,
-        imageFileName: sanitizedName,
+        imageFileName: context.baseFileName,
         displayName: displayName,
         group: group
       )

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -1,0 +1,276 @@
+//
+//  SnapshotCIExportCoordinator.swift
+//  SnapshottingTests
+//
+//  Manages CI export of snapshot PNGs and JSON sidecar metadata
+//  directly to the filesystem when SNAPSHOTS_EXPORT_DIR is set.
+//
+
+import Foundation
+import XCTest
+@_implementationOnly import SnapshotPreviewsCore
+
+// MARK: - Snapshot Context
+
+struct SnapshotContext: Sendable, Encodable {
+  let baseFileName: String
+  let testName: String
+  let typeName: String
+  let typeDisplayName: String
+  let fileId: String?
+  let line: Int?
+  let previewDisplayName: String?
+  let previewIndex: Int
+  let previewId: String
+  let orientation: String
+  let declaredDevice: String?
+  let simulatorDeviceName: String?
+  let simulatorModelIdentifier: String?
+  let precision: Float?
+  let accessibilityEnabled: Bool?
+  let colorScheme: String?
+  let appStoreSnapshot: Bool?
+}
+
+// MARK: - Sidecar Model
+
+private struct SnapshotCIExportSidecar: Sendable, Encodable {
+  let context: SnapshotContext
+  let imageFileName: String
+  let displayName: String
+  let group: String
+
+  private enum ExtraKeys: String, CodingKey {
+    case image_file_name
+    case display_name
+    case group
+  }
+
+  func encode(to encoder: Encoder) throws {
+    try context.encode(to: encoder)
+    var container = encoder.container(keyedBy: ExtraKeys.self)
+    try container.encode(imageFileName, forKey: .image_file_name)
+    try container.encode(displayName, forKey: .display_name)
+    try container.encode(group, forKey: .group)
+  }
+}
+
+// MARK: - Coordinator
+
+final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
+
+  static let envKey = "SNAPSHOTS_EXPORT_DIR"
+
+  private let exportDirectoryURL: URL
+  private let writeQueue: OperationQueue
+  private let fileManager: FileManager
+  private let stateLock = NSLock()
+  private var hasDrained = false
+
+  // MARK: - Shared Instance
+
+  private static var _shared: SnapshotCIExportCoordinator?
+
+  static func sharedIfEnabled(
+    environment: [String: String] = ProcessInfo.processInfo.environment
+  ) -> SnapshotCIExportCoordinator? {
+    if let _shared { return _shared }
+
+    guard let exportDir = environment[envKey] else {
+      return nil
+    }
+
+    let trimmed = exportDir.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      preconditionFailure(
+        "\(envKey) is set but empty. Provide a valid directory path."
+      )
+    }
+
+    let url: URL
+    if trimmed.hasPrefix("/") {
+      url = URL(fileURLWithPath: trimmed, isDirectory: true).standardizedFileURL
+    } else {
+      url = URL(
+        fileURLWithPath: FileManager.default.currentDirectoryPath,
+        isDirectory: true
+      )
+      .appendingPathComponent(trimmed, isDirectory: true)
+      .standardizedFileURL
+    }
+
+    let coordinator = Self(exportDirectoryURL: url)
+    _shared = coordinator
+    XCTestObservationCenter.shared.addTestObserver(coordinator)
+    return coordinator
+  }
+
+  /// Resets shared state. Exposed for testing only.
+  static func resetShared() {
+    if let shared = _shared {
+      XCTestObservationCenter.shared.removeTestObserver(shared)
+    }
+    _shared = nil
+  }
+
+  // MARK: - Init
+
+  init(
+    exportDirectoryURL: URL,
+    fileManager: FileManager = .default,
+    writeQueue: OperationQueue = .defaultQueue
+  ) {
+    self.exportDirectoryURL = exportDirectoryURL
+    self.fileManager = fileManager
+    self.writeQueue = writeQueue
+
+    super.init()
+
+    do {
+      try self.fileManager.createDirectory(
+        at: exportDirectoryURL,
+        withIntermediateDirectories: true
+      )
+    } catch {
+      preconditionFailure(
+        "Failed to create snapshot export directory at \(exportDirectoryURL.path): \(error)"
+      )
+    }
+  }
+
+  // MARK: - Filename Sanitization
+
+  static func sanitize(_ raw: String) -> String {
+    var result = ""
+    var lastWasUnderscore = false
+
+    for c in raw {
+      if c.isLetter || c.isNumber || c == "." || c == "-" {
+        result.append(c)
+        lastWasUnderscore = false
+      } else if !lastWasUnderscore {
+        result.append("_")
+        lastWasUnderscore = true
+      }
+    }
+
+    result = result.trimmingCharacters(in: CharacterSet(charactersIn: "_.-"))
+
+    return result.isEmpty ? "snapshot" : result
+  }
+
+  // MARK: - Export
+
+  private static func canonicalGroup(for context: SnapshotContext) -> String {
+    if let fileId = context.fileId, !fileId.isEmpty {
+      return fileId
+    }
+
+    if !context.typeDisplayName.isEmpty {
+      return context.typeDisplayName
+    }
+
+    return context.typeName
+  }
+
+  private static func canonicalDisplayName(for context: SnapshotContext) -> String {
+    if let previewDisplayName = context.previewDisplayName, !previewDisplayName.isEmpty {
+      return previewDisplayName
+    }
+
+    if context.fileId != nil, let line = context.line {
+      return "At line #\(line)"
+    }
+
+    return String(context.previewIndex)
+  }
+
+  /// Enqueues a snapshot export (PNG + JSON sidecar) to the export directory.
+  ///
+  /// PNG encoding and file writes are dispatched to a concurrent background queue
+  /// so the calling test can proceed to the next preview immediately.
+  func enqueueExport(
+    result: SnapshotResult,
+    context: SnapshotContext
+  ) {
+    let sanitizedName = Self.sanitize(context.baseFileName)
+    let pngFileName = "\(sanitizedName).png"
+    let jsonFileName = "\(sanitizedName).json"
+
+    let displayName = Self.canonicalDisplayName(for: context)
+    let group = Self.canonicalGroup(for: context)
+    let exportDir = exportDirectoryURL
+    
+    guard case .success(let image) = result.image else { return }
+    
+    writeQueue.addOperation {
+      let pngURL = exportDir.appendingPathComponent(pngFileName)
+      guard let pngData = image.emg.pngData() else {
+        NSLog("[SnapshotCIExport] Failed to encode PNG for %@", pngFileName)
+        return
+      }
+      do {
+        try pngData.write(to: pngURL, options: .atomic)
+      } catch {
+        NSLog("[SnapshotCIExport] Failed to write PNG %@: %@", pngFileName, "\(error)")
+        return
+      }
+
+      let sidecar = SnapshotCIExportSidecar(
+        context: context,
+        imageFileName: sanitizedName,
+        displayName: displayName,
+        group: group
+      )
+
+      let jsonURL = exportDir.appendingPathComponent(jsonFileName)
+      do {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(sidecar)
+        try data.write(to: jsonURL, options: .atomic)
+      } catch {
+        NSLog("[SnapshotCIExport] Failed to write sidecar %@: %@", jsonFileName, "\(error)")
+      }
+    }
+  }
+
+  // MARK: - Drain
+
+  /// Waits for all queued PNG and sidecar writes to complete.
+  ///
+  /// Called automatically via `testBundleDidFinish`. Safe to call multiple times —
+  /// only the first call performs the drain.
+  func drain() {
+    stateLock.lock()
+    guard !hasDrained else {
+      stateLock.unlock()
+      return
+    }
+    hasDrained = true
+    stateLock.unlock()
+
+    guard fileManager.fileExists(atPath: exportDirectoryURL.path) else { return }
+
+    let semaphore = DispatchSemaphore(value: 0)
+    writeQueue.addBarrierBlock {
+      semaphore.signal()
+    }
+    semaphore.wait()
+  }
+
+  // MARK: - XCTestObservation
+
+  func testBundleDidFinish(_ testBundle: Bundle) {
+    drain()
+  }
+}
+
+private extension OperationQueue {
+  static var defaultQueue: OperationQueue {
+    let queue = OperationQueue()
+    queue.maxConcurrentOperationCount = 20
+    queue.qualityOfService = .userInitiated
+    return queue
+  }
+}

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -250,11 +250,7 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
     hasDrained = true
     stateLock.unlock()
 
-    let semaphore = DispatchSemaphore(value: 0)
-    writeQueue.addBarrierBlock {
-      semaphore.signal()
-    }
-    semaphore.wait()
+    writeQueue.waitUntilAllOperationsAreFinished()
   }
 
   // MARK: - XCTestObservation

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -69,9 +69,9 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
 
   // MARK: - Shared Instance
 
-  private static var _shared: SnapshotCIExportCoordinator?
+  @MainActor private static var _shared: SnapshotCIExportCoordinator?
 
-  static func sharedIfEnabled(
+  @MainActor static func sharedIfEnabled(
     environment: [String: String] = ProcessInfo.processInfo.environment
   ) -> SnapshotCIExportCoordinator? {
     if let _shared { return _shared }
@@ -106,7 +106,7 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
   }
 
   /// Resets shared state. Exposed for testing only.
-  static func resetShared() {
+  @MainActor static func resetShared() {
     if let shared = _shared {
       XCTestObservationCenter.shared.removeTestObserver(shared)
     }

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -145,7 +145,7 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
     var lastWasUnderscore = false
 
     for c in raw {
-      if c.isLetter || c.isNumber || c == "." || c == "-" {
+      if c.isLetter || c.isNumber || c == "." || c == "-" || c == "_" {
         result.append(c)
         lastWasUnderscore = false
       } else if !lastWasUnderscore {

--- a/Sources/SnapshottingTests/SnapshotTest.swift
+++ b/Sources/SnapshottingTests/SnapshotTest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 @_implementationOnly import SnapshotPreviewsCore
-@_exported import enum SwiftUI.ColorScheme
+import enum SwiftUI.ColorScheme
 import XCTest
 
 extension ColorScheme {
@@ -45,18 +45,6 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
     nil
   }
 
-  /// Override to render each preview in multiple color schemes.
-  ///
-  /// When `nil` (the default), each preview renders once with whatever color scheme
-  /// it naturally uses — no override is applied. When set to e.g. `[.light, .dark]`,
-  /// each preview renders once per scheme, producing separate snapshot files suffixed
-  /// with the scheme name.
-  ///
-  /// - Returns: An optional array of `ColorScheme` values, or `nil` for no override.
-  open class func colorSchemes() -> [ColorScheme]? {
-    nil
-  }
-  
   #if canImport(UIKit) && !os(watchOS) && !os(visionOS) && !os(tvOS)
   open class func setupA11y() -> ((UIViewController, UIWindow, PreviewLayout) -> UIView)? {
     return nil
@@ -168,124 +156,68 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
       typeFileName = Self.previewCountForFileId[fileId]! > 1 ? "\(fileId):\(lineNumber)" : fileId
     }
 
-    let schemes = Self.colorSchemes()
-    let renderPasses: [(scheme: ColorScheme?, suffix: String)] = if let schemes {
-      schemes.map { ($0, "_\($0.stringValue)") }
+    var result: SnapshotResult? = nil
+    let expectation = XCTestExpectation()
+    strategy.render(preview: preview) { snapshotResult in
+      result = snapshotResult
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+    guard let result else {
+      XCTFail("Did not render")
+      return
+    }
+
+    let previewGroup = SnapshotCIExportCoordinator.canonicalGroup(
+      fileId: previewType.fileID,
+      typeDisplayName: previewType.displayName,
+      typeName: previewType.typeName
+    )
+    let duplicateDisplayNameCount = preview.displayName.flatMap {
+      Self.previewDisplayNameCountByGroup[previewGroup]?[$0]
+    } ?? 0
+    let fileNameComponent = Self.resolvedFileNameComponent(
+      fileId: previewType.fileID,
+      line: previewType.line,
+      previewDisplayName: preview.displayName,
+      previewIndex: discoveredPreview.index,
+      duplicateDisplayNameCount: duplicateDisplayNameCount
+    )
+    let baseFileName = SnapshotCIExportCoordinator.sanitize(
+      "\(typeFileName)_\(fileNameComponent)"
+    )
+    let colorSchemeValue = result.colorScheme?.stringValue
+
+    let context = SnapshotContext(
+      baseFileName: baseFileName,
+      testName: name,
+      typeName: previewType.typeName,
+      typeDisplayName: previewType.displayName,
+      fileId: previewType.fileID,
+      line: previewType.line,
+      previewDisplayName: preview.displayName,
+      previewIndex: discoveredPreview.index,
+      previewId: preview.previewId,
+      orientation: preview.orientation.id,
+      declaredDevice: preview.device?.rawValue,
+      simulatorDeviceName: ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"],
+      simulatorModelIdentifier: ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"],
+      precision: result.precision,
+      accessibilityEnabled: result.accessibilityEnabled,
+      colorScheme: colorSchemeValue,
+      appStoreSnapshot: result.appStoreSnapshot)
+
+    if let coordinator = SnapshotCIExportCoordinator.sharedIfEnabled() {
+      coordinator.enqueueExport(result: result, context: context)
     } else {
-      [(nil, "")]
-    }
-
-    defer {
-      if schemes != nil {
-        applyColorSchemeOverride(nil)
-      }
-    }
-
-    for pass in renderPasses {
-      if let scheme = pass.scheme {
-        applyColorSchemeOverride(scheme)
-      }
-
-      var result: SnapshotResult? = nil
-      let expectation = XCTestExpectation()
-      strategy.render(preview: preview) { snapshotResult in
-        result = snapshotResult
-        expectation.fulfill()
-      }
-      wait(for: [expectation], timeout: 10)
-      guard let result else {
-        XCTFail("Did not render")
-        continue
-      }
-
-      let previewGroup = SnapshotCIExportCoordinator.canonicalGroup(
-        fileId: previewType.fileID,
-        typeDisplayName: previewType.displayName,
-        typeName: previewType.typeName
-      )
-      let duplicateDisplayNameCount = preview.displayName.flatMap {
-        Self.previewDisplayNameCountByGroup[previewGroup]?[$0]
-      } ?? 0
-      let fileNameComponent = Self.resolvedFileNameComponent(
-        fileId: previewType.fileID,
-        line: previewType.line,
-        previewDisplayName: preview.displayName,
-        previewIndex: discoveredPreview.index,
-        duplicateDisplayNameCount: duplicateDisplayNameCount
-      )
-      let baseFileName = SnapshotCIExportCoordinator.sanitize(
-        "\(typeFileName)_\(fileNameComponent)\(pass.suffix)"
-      )
-      let colorSchemeValue = pass.scheme?.stringValue ?? result.colorScheme?.stringValue
-
-      let context = SnapshotContext(
-        baseFileName: baseFileName,
-        testName: name,
-        typeName: previewType.typeName,
-        typeDisplayName: previewType.displayName,
-        fileId: previewType.fileID,
-        line: previewType.line,
-        previewDisplayName: preview.displayName,
-        previewIndex: discoveredPreview.index,
-        previewId: preview.previewId,
-        orientation: preview.orientation.id,
-        declaredDevice: preview.device?.rawValue,
-        simulatorDeviceName: ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"],
-        simulatorModelIdentifier: ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"],
-        precision: result.precision,
-        accessibilityEnabled: result.accessibilityEnabled,
-        colorScheme: colorSchemeValue,
-        appStoreSnapshot: result.appStoreSnapshot)
-
-      if let coordinator = SnapshotCIExportCoordinator.sharedIfEnabled() {
-        coordinator.enqueueExport(result: result, context: context)
-      } else {
-        do {
-          let attachment = try XCTAttachment(image: result.image.get())
-          attachment.name = baseFileName
-          attachment.lifetime = .keepAlways
-          add(attachment)
-        } catch {
-          XCTFail("Error \(error)")
-        }
+      do {
+        let attachment = try XCTAttachment(image: result.image.get())
+        attachment.name = baseFileName
+        attachment.lifetime = .keepAlways
+        add(attachment)
+      } catch {
+        XCTFail("Error \(error)")
       }
     }
   }
-}
-
-// Color scheme override helpers — kept outside the open class to avoid
-// @_implementationOnly deserialization issues with private members.
-
-@MainActor
-private func applyColorSchemeOverride(_ scheme: ColorScheme?) {
-  #if canImport(UIKit) && !os(watchOS)
-  let style: UIUserInterfaceStyle
-  switch scheme {
-  case .light:
-    style = .light
-  case .dark:
-    style = .dark
-  case nil:
-    style = .unspecified
-  @unknown default:
-    style = .unspecified
-  }
-  for scene in UIApplication.shared.connectedScenes {
-    guard let windowScene = scene as? UIWindowScene else { continue }
-    for window in windowScene.windows {
-      window.overrideUserInterfaceStyle = style
-    }
-  }
-  #elseif canImport(AppKit) && !targetEnvironment(macCatalyst)
-  switch scheme {
-  case .light:
-    NSApplication.shared.appearance = NSAppearance(named: .aqua)
-  case .dark:
-    NSApplication.shared.appearance = NSAppearance(named: .darkAqua)
-  case nil:
-    NSApplication.shared.appearance = nil
-  @unknown default:
-    NSApplication.shared.appearance = nil
-  }
-  #endif
 }

--- a/Sources/SnapshottingTests/SnapshotTest.swift
+++ b/Sources/SnapshottingTests/SnapshotTest.swift
@@ -7,7 +7,21 @@
 
 import Foundation
 @_implementationOnly import SnapshotPreviewsCore
+@_exported import enum SwiftUI.ColorScheme
 import XCTest
+
+extension ColorScheme {
+  var stringValue: String {
+    switch self {
+    case .light:
+      return "light"
+    case .dark:
+      return "dark"
+    @unknown default:
+      return "unknown"
+    }
+  }
+}
 
 /// A test class for generating snapshots of Xcode previews.
 ///
@@ -28,6 +42,18 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
   /// Override this method to specify which previews should be excluded from the snapshot test.
   /// - Returns: An optional array of String containing the names of previews to be excluded.
   open class func excludedSnapshotPreviews() -> [String]? {
+    nil
+  }
+
+  /// Override to render each preview in multiple color schemes.
+  ///
+  /// When `nil` (the default), each preview renders once with whatever color scheme
+  /// it naturally uses — no override is applied. When set to e.g. `[.light, .dark]`,
+  /// each preview renders once per scheme, producing separate snapshot files suffixed
+  /// with the scheme name.
+  ///
+  /// - Returns: An optional array of `ColorScheme` values, or `nil` for no override.
+  open class func colorSchemes() -> [ColorScheme]? {
     nil
   }
   
@@ -63,20 +89,48 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
   static private var previews: [SnapshotPreviewsCore.PreviewType] = []
   
   static private var previewCountForFileId: [String: Int] = [:]
+  static private var previewDisplayNameCountByGroup: [String: [String: Int]] = [:]
 
-  /// Discovers all relevant previews based on inclusion and exclusion filters. Subclasses should NOT override this method.
-  ///
-  /// This method uses `FindPreviews` to locate all previews, applying any specified filters.
-  /// - Returns: An array of `DiscoveredPreview` objects representing the found previews.
+  static func resolvedFileNameComponent(
+    fileId: String?,
+    line: Int?,
+    previewDisplayName: String?,
+    previewIndex: Int,
+    duplicateDisplayNameCount: Int
+  ) -> String {
+    if let previewDisplayName, !previewDisplayName.isEmpty, duplicateDisplayNameCount <= 1 {
+      return previewDisplayName
+    }
+
+    if let fileId, !fileId.isEmpty, let line {
+      return "line-\(line)"
+    }
+
+    return String(previewIndex)
+  }
+
   @MainActor
   override class func discoverPreviews() -> [DiscoveredPreview] {
+    _ = SnapshotCIExportCoordinator.sharedIfEnabled()
+
     previews = FindPreviews.findPreviews(included: Self.snapshotPreviews(), excluded: Self.excludedSnapshotPreviews())
-    
-    for preview in previews {
-        guard let fileId = preview.fileID else { continue }
+    previewCountForFileId = [:]
+    previewDisplayNameCountByGroup = [:]
+
+    for previewType in previews {
+      if let fileId = previewType.fileID {
         previewCountForFileId[fileId, default: 0] += 1
+      }
+
+      let group = previewType.fileID ?? previewType.typeName
+      for preview in previewType.previews {
+        guard let previewDisplayName = preview.displayName, !previewDisplayName.isEmpty else {
+          continue
+        }
+        previewDisplayNameCountByGroup[group, default: [:]][previewDisplayName, default: 0] += 1
+      }
     }
-    
+
     return previews.map { DiscoveredPreview.from(previewType: $0) }
   }
 
@@ -88,47 +142,139 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
   /// - Parameter discoveredPreview: A `DiscoveredPreviewAndIndex` object representing the preview to be tested.
   @MainActor
   override func testPreview(_ discoveredPreview: DiscoveredPreviewAndIndex) {
-    let previewType = Self.previews.first { $0.typeName == discoveredPreview.preview.typeName }
-    guard let previewType = previewType else {
+    guard let previewType = Self.previews.first(where: { $0.typeName == discoveredPreview.preview.typeName }) else {
       XCTFail("Preview type not found")
       return
     }
 
     let preview = previewType.previews[discoveredPreview.index]
-    var result: SnapshotResult? = nil
-    let strategy: RenderingStrategy
-    if let renderingStrategy = Self.renderingStrategy {
-      strategy = renderingStrategy
-    } else {
-#if canImport(UIKit) && !os(watchOS) && !os(visionOS) && !os(tvOS)
-      strategy = Self.makeRenderingStrategy(a11y: Self.setupA11y())
+
+    // Lazily create the rendering strategy
+    if Self.renderingStrategy == nil {
+      #if canImport(UIKit) && !os(watchOS) && !os(visionOS) && !os(tvOS)
+      Self.renderingStrategy = Self.makeRenderingStrategy(a11y: Self.setupA11y())
       #else
-      strategy = Self.makeRenderingStrategy()
+      Self.renderingStrategy = Self.makeRenderingStrategy()
       #endif
-      Self.renderingStrategy = strategy
     }
-    let expectation = XCTestExpectation()
-    strategy.render(preview: preview) { snapshotResult in
-      result = snapshotResult
-      expectation.fulfill()
-    }
-    wait(for: [expectation], timeout: 10)
-    guard let result else {
-      XCTFail("Did not render")
-      return
-    }
+    let strategy = Self.renderingStrategy!
 
     var typeFileName = previewType.displayName
     if let fileId = previewType.fileID, let lineNumber = previewType.line {
       typeFileName = Self.previewCountForFileId[fileId]! > 1 ? "\(fileId):\(lineNumber)" : fileId
     }
-    do {
-      let attachment = try XCTAttachment(image: result.image.get())
-      attachment.name = "\(typeFileName)_\(preview.displayName ?? String(discoveredPreview.index))"
-      attachment.lifetime = .keepAlways
-      add(attachment)
-    } catch {
-      XCTFail("Error \(error)")
+
+    let schemes = Self.colorSchemes()
+    let renderPasses: [(scheme: ColorScheme?, suffix: String)] = if let schemes {
+      schemes.map { ($0, "_\($0.stringValue)") }
+    } else {
+      [(nil, "")]
+    }
+
+    for pass in renderPasses {
+      if let scheme = pass.scheme {
+        applyColorSchemeOverride(scheme)
+      }
+
+      var result: SnapshotResult? = nil
+      let expectation = XCTestExpectation()
+      strategy.render(preview: preview) { snapshotResult in
+        result = snapshotResult
+        expectation.fulfill()
+      }
+      wait(for: [expectation], timeout: 10)
+      guard let result else {
+        XCTFail("Did not render")
+        continue
+      }
+
+      let previewGroup = previewType.fileID ?? previewType.typeName
+      let duplicateDisplayNameCount = preview.displayName.flatMap {
+        Self.previewDisplayNameCountByGroup[previewGroup]?[$0]
+      } ?? 0
+      let fileNameComponent = Self.resolvedFileNameComponent(
+        fileId: previewType.fileID,
+        line: previewType.line,
+        previewDisplayName: preview.displayName,
+        previewIndex: discoveredPreview.index,
+        duplicateDisplayNameCount: duplicateDisplayNameCount
+      )
+      let baseFileName = "\(typeFileName)_\(fileNameComponent)\(pass.suffix)"
+      let colorSchemeValue = pass.scheme?.stringValue ?? result.colorScheme?.stringValue
+
+      let context = SnapshotContext(
+        baseFileName: baseFileName,
+        testName: name,
+        typeName: previewType.typeName,
+        typeDisplayName: previewType.displayName,
+        fileId: previewType.fileID,
+        line: previewType.line,
+        previewDisplayName: preview.displayName,
+        previewIndex: discoveredPreview.index,
+        previewId: preview.previewId,
+        orientation: preview.orientation.id,
+        declaredDevice: preview.device?.rawValue,
+        simulatorDeviceName: ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"],
+        simulatorModelIdentifier: ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"],
+        precision: result.precision,
+        accessibilityEnabled: result.accessibilityEnabled,
+        colorScheme: colorSchemeValue,
+        appStoreSnapshot: result.appStoreSnapshot)
+
+      if let coordinator = SnapshotCIExportCoordinator.sharedIfEnabled() {
+        coordinator.enqueueExport(result: result, context: context)
+      } else {
+        do {
+          let attachment = try XCTAttachment(image: result.image.get())
+          attachment.name = baseFileName
+          attachment.lifetime = .keepAlways
+          add(attachment)
+        } catch {
+          XCTFail("Error \(error)")
+        }
+      }
+    }
+
+    // Reset override after all passes
+    if schemes != nil {
+      applyColorSchemeOverride(nil)
     }
   }
+}
+
+// Color scheme override helpers — kept outside the open class to avoid
+// @_implementationOnly deserialization issues with private members.
+
+@MainActor
+private func applyColorSchemeOverride(_ scheme: ColorScheme?) {
+  #if canImport(UIKit) && !os(watchOS)
+  let style: UIUserInterfaceStyle
+  switch scheme {
+  case .light:
+    style = .light
+  case .dark:
+    style = .dark
+  case nil:
+    style = .unspecified
+  @unknown default:
+    style = .unspecified
+  }
+  for scene in UIApplication.shared.connectedScenes {
+    guard let windowScene = scene as? UIWindowScene else { continue }
+    for window in windowScene.windows {
+      window.overrideUserInterfaceStyle = style
+    }
+  }
+  #elseif canImport(AppKit) && !targetEnvironment(macCatalyst)
+  switch scheme {
+  case .light:
+    NSApplication.shared.appearance = NSAppearance(named: .aqua)
+  case .dark:
+    NSApplication.shared.appearance = NSAppearance(named: .darkAqua)
+  case nil:
+    NSApplication.shared.appearance = nil
+  @unknown default:
+    NSApplication.shared.appearance = nil
+  }
+  #endif
 }

--- a/Sources/SnapshottingTests/SnapshotTest.swift
+++ b/Sources/SnapshottingTests/SnapshotTest.swift
@@ -171,6 +171,12 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
       [(nil, "")]
     }
 
+    defer {
+      if schemes != nil {
+        applyColorSchemeOverride(nil)
+      }
+    }
+
     for pass in renderPasses {
       if let scheme = pass.scheme {
         applyColorSchemeOverride(scheme)
@@ -233,11 +239,6 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
           XCTFail("Error \(error)")
         }
       }
-    }
-
-    // Reset override after all passes
-    if schemes != nil {
-      applyColorSchemeOverride(nil)
     }
   }
 }

--- a/Sources/SnapshottingTests/SnapshotTest.swift
+++ b/Sources/SnapshottingTests/SnapshotTest.swift
@@ -73,9 +73,10 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
   }
     #endif
   private static var renderingStrategy: RenderingStrategy? = nil
+  @MainActor private static var ciExportCoordinator: SnapshotCIExportCoordinator?
 
   static private var previews: [SnapshotPreviewsCore.PreviewType] = []
-  
+
   static private var previewCountForFileId: [String: Int] = [:]
   static private var previewDisplayNameCountByGroup: [String: [String: Int]] = [:]
 
@@ -99,7 +100,7 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
 
   @MainActor
   override class func discoverPreviews() -> [DiscoveredPreview] {
-    _ = SnapshotCIExportCoordinator.sharedIfEnabled()
+    ciExportCoordinator = SnapshotCIExportCoordinator.createFromEnvironment()
 
     previews = FindPreviews.findPreviews(included: Self.snapshotPreviews(), excluded: Self.excludedSnapshotPreviews())
     previewCountForFileId = [:]
@@ -142,14 +143,17 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
     let preview = previewType.previews[discoveredPreview.index]
 
     // Lazily create the rendering strategy
-    if Self.renderingStrategy == nil {
+    let strategy: RenderingStrategy
+    if let existing = Self.renderingStrategy {
+      strategy = existing
+    } else {
       #if canImport(UIKit) && !os(watchOS) && !os(visionOS) && !os(tvOS)
-      Self.renderingStrategy = Self.makeRenderingStrategy(a11y: Self.setupA11y())
+      strategy = Self.makeRenderingStrategy(a11y: Self.setupA11y())
       #else
-      Self.renderingStrategy = Self.makeRenderingStrategy()
+      strategy = Self.makeRenderingStrategy()
       #endif
+      Self.renderingStrategy = strategy
     }
-    let strategy = Self.renderingStrategy!
 
     var typeFileName = previewType.displayName
     if let fileId = previewType.fileID, let lineNumber = previewType.line {
@@ -186,28 +190,26 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
     let baseFileName = SnapshotCIExportCoordinator.sanitize(
       "\(typeFileName)_\(fileNameComponent)"
     )
-    let colorSchemeValue = result.colorScheme?.stringValue
-
-    let context = SnapshotContext(
-      baseFileName: baseFileName,
-      testName: name,
-      typeName: previewType.typeName,
-      typeDisplayName: previewType.displayName,
-      fileId: previewType.fileID,
-      line: previewType.line,
-      previewDisplayName: preview.displayName,
-      previewIndex: discoveredPreview.index,
-      previewId: preview.previewId,
-      orientation: preview.orientation.id,
-      declaredDevice: preview.device?.rawValue,
-      simulatorDeviceName: ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"],
-      simulatorModelIdentifier: ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"],
-      precision: result.precision,
-      accessibilityEnabled: result.accessibilityEnabled,
-      colorScheme: colorSchemeValue,
-      appStoreSnapshot: result.appStoreSnapshot)
-
-    if let coordinator = SnapshotCIExportCoordinator.sharedIfEnabled() {
+    if let coordinator = Self.ciExportCoordinator {
+      let colorSchemeValue = result.colorScheme?.stringValue
+      let context = SnapshotContext(
+        baseFileName: baseFileName,
+        testName: name,
+        typeName: previewType.typeName,
+        typeDisplayName: previewType.displayName,
+        fileId: previewType.fileID,
+        line: previewType.line,
+        previewDisplayName: preview.displayName,
+        previewIndex: discoveredPreview.index,
+        previewId: preview.previewId,
+        orientation: preview.orientation.id,
+        declaredDevice: preview.device?.rawValue,
+        simulatorDeviceName: ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"],
+        simulatorModelIdentifier: ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"],
+        precision: result.precision,
+        accessibilityEnabled: result.accessibilityEnabled,
+        colorScheme: colorSchemeValue,
+        appStoreSnapshot: result.appStoreSnapshot)
       coordinator.enqueueExport(result: result, context: context)
     } else {
       do {

--- a/Sources/SnapshottingTests/SnapshotTest.swift
+++ b/Sources/SnapshottingTests/SnapshotTest.swift
@@ -122,7 +122,11 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
         previewCountForFileId[fileId, default: 0] += 1
       }
 
-      let group = previewType.fileID ?? previewType.typeName
+      let group = SnapshotCIExportCoordinator.canonicalGroup(
+        fileId: previewType.fileID,
+        typeDisplayName: previewType.displayName,
+        typeName: previewType.typeName
+      )
       for preview in previewType.previews {
         guard let previewDisplayName = preview.displayName, !previewDisplayName.isEmpty else {
           continue
@@ -194,7 +198,11 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
         continue
       }
 
-      let previewGroup = previewType.fileID ?? previewType.typeName
+      let previewGroup = SnapshotCIExportCoordinator.canonicalGroup(
+        fileId: previewType.fileID,
+        typeDisplayName: previewType.displayName,
+        typeName: previewType.typeName
+      )
       let duplicateDisplayNameCount = preview.displayName.flatMap {
         Self.previewDisplayNameCountByGroup[previewGroup]?[$0]
       } ?? 0

--- a/Sources/SnapshottingTests/SnapshotTest.swift
+++ b/Sources/SnapshottingTests/SnapshotTest.swift
@@ -213,7 +213,9 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
         previewIndex: discoveredPreview.index,
         duplicateDisplayNameCount: duplicateDisplayNameCount
       )
-      let baseFileName = "\(typeFileName)_\(fileNameComponent)\(pass.suffix)"
+      let baseFileName = SnapshotCIExportCoordinator.sanitize(
+        "\(typeFileName)_\(fileNameComponent)\(pass.suffix)"
+      )
       let colorSchemeValue = pass.scheme?.stringValue ?? result.colorScheme?.stringValue
 
       let context = SnapshotContext(

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -23,35 +23,26 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     super.setUp()
     tempDir = FileManager.default.temporaryDirectory
       .appendingPathComponent("SnapshotCIExportTests-\(UUID().uuidString)")
-    SnapshotCIExportCoordinator.resetShared()
   }
 
   override func tearDown() {
     try? FileManager.default.removeItem(at: tempDir)
-    SnapshotCIExportCoordinator.resetShared()
     super.tearDown()
   }
 
-  // MARK: - Shared Instance Gating
+  // MARK: - Factory
 
-  func testSharedIfEnabledReturnsNilWhenEnvVarAbsent() {
-    let coordinator = SnapshotCIExportCoordinator.sharedIfEnabled(environment: [:])
+  func testCreateFromEnvironmentReturnsNilWhenEnvVarAbsent() {
+    let coordinator = SnapshotCIExportCoordinator.createFromEnvironment(environment: [:])
     XCTAssertNil(coordinator)
   }
 
-  func testSharedIfEnabledReturnsCoordinatorWhenEnvVarSet() {
-    let coordinator = SnapshotCIExportCoordinator.sharedIfEnabled(
+  func testCreateFromEnvironmentReturnsCoordinatorWhenEnvVarSet() {
+    let coordinator = SnapshotCIExportCoordinator.createFromEnvironment(
       environment: [SnapshotCIExportCoordinator.envKey: tempDir.path]
     )
     XCTAssertNotNil(coordinator)
     XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.path))
-  }
-
-  func testSharedIfEnabledReturnsSameInstanceOnRepeatedCalls() {
-    let env = [SnapshotCIExportCoordinator.envKey: tempDir.path]
-    let first = SnapshotCIExportCoordinator.sharedIfEnabled(environment: env)
-    let second = SnapshotCIExportCoordinator.sharedIfEnabled(environment: env)
-    XCTAssertTrue(first === second, "Should return the same cached instance")
   }
 
   // MARK: - Filename Sanitization

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -133,9 +133,8 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     coordinator.enqueueExport(result: makeSuccessResult(), context: context)
     coordinator.drain()
 
-    let sanitized = SnapshotCIExportCoordinator.sanitize(context.baseFileName)
-    let jsonURL = tempDir.appendingPathComponent("\(sanitized).json")
-    let pngURL = tempDir.appendingPathComponent("\(sanitized).png")
+    let jsonURL = tempDir.appendingPathComponent("\(context.baseFileName).json")
+    let pngURL = tempDir.appendingPathComponent("\(context.baseFileName).png")
 
     XCTAssertTrue(FileManager.default.fileExists(atPath: jsonURL.path))
     XCTAssertTrue(FileManager.default.fileExists(atPath: pngURL.path))
@@ -146,7 +145,7 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
   func testSidecarUsesPreviewDisplayNameAndTypeDisplayNameForPreviewProviderPresentation() throws {
     let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
     let context = makeContext(
-      baseFileName: "Login Screen_Dark Mode",
+      baseFileName: "Login_Screen_Dark_Mode",
       typeName: "MyModule.LoginScreen_Previews",
       typeDisplayName: "Login Screen",
       previewDisplayName: "Dark Mode"
@@ -157,7 +156,7 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
 
     let json = try readJSON(forBaseFileName: context.baseFileName)
 
-    XCTAssertEqual(json["image_file_name"] as? String, SnapshotCIExportCoordinator.sanitize(context.baseFileName))
+    XCTAssertEqual(json["image_file_name"] as? String, context.baseFileName)
     XCTAssertEqual(json["display_name"] as? String, "Dark Mode")
     XCTAssertEqual(json["group"] as? String, "Login Screen")
   }
@@ -267,9 +266,8 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     coordinator.enqueueExport(result: makeFailureResult(), context: context)
     coordinator.drain()
 
-    let sanitized = SnapshotCIExportCoordinator.sanitize(context.baseFileName)
-    XCTAssertFalse(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(sanitized).png").path))
-    XCTAssertFalse(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(sanitized).json").path))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(context.baseFileName).png").path))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(context.baseFileName).json").path))
   }
 
   // MARK: - Drain Semantics
@@ -282,8 +280,7 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     coordinator.drain()
     coordinator.drain()
 
-    let sanitized = SnapshotCIExportCoordinator.sanitize(context.baseFileName)
-    XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(sanitized).json").path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(context.baseFileName).json").path))
   }
 
   func testDrainOnEmptyQueueDoesNotCrash() {
@@ -311,9 +308,8 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     coordinator.drain()
 
     for context in contexts {
-      let sanitized = SnapshotCIExportCoordinator.sanitize(context.baseFileName)
-      XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(sanitized).png").path))
-      XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(sanitized).json").path))
+      XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(context.baseFileName).png").path))
+      XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(context.baseFileName).json").path))
     }
   }
 }
@@ -323,8 +319,7 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
 extension SnapshotCIExportCoordinatorTests {
 
   private func readJSON(forBaseFileName baseFileName: String) throws -> [String: Any] {
-    let sanitized = SnapshotCIExportCoordinator.sanitize(baseFileName)
-    let data = try Data(contentsOf: tempDir.appendingPathComponent("\(sanitized).json"))
+    let data = try Data(contentsOf: tempDir.appendingPathComponent("\(baseFileName).json"))
     return try JSONSerialization.jsonObject(with: data) as! [String: Any]
   }
 

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -14,6 +14,7 @@ import UIKit
 import AppKit
 #endif
 
+@MainActor
 final class SnapshotCIExportCoordinatorTests: XCTestCase {
 
   private var tempDir: URL!

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -67,9 +67,14 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     XCTAssertEqual(a, b)
   }
 
-  func testSanitizeCollapsesRepeatedUnderscores() {
-    let result = SnapshotCIExportCoordinator.sanitize("A///B___C")
-    XCTAssertFalse(result.contains("__"))
+  func testSanitizeCollapsesRepeatedUnsafeCharacters() {
+    let result = SnapshotCIExportCoordinator.sanitize("A///B   C")
+    XCTAssertFalse(result.contains("__"), "Consecutive unsafe chars should collapse to a single underscore")
+  }
+
+  func testSanitizePreservesExistingUnderscores() {
+    let result = SnapshotCIExportCoordinator.sanitize("A___B")
+    XCTAssertEqual(result, "A___B", "Underscores in the input should be preserved as-is")
   }
 
   func testSanitizeFallsBackForEmptyResult() {

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -1,0 +1,402 @@
+//
+//  SnapshotCIExportCoordinatorTests.swift
+//  SnapshottingTestsTests
+//
+
+import Foundation
+import XCTest
+@testable import SnapshottingTests
+import SnapshotPreviewsCore
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+final class SnapshotCIExportCoordinatorTests: XCTestCase {
+
+  private var tempDir: URL!
+
+  override func setUp() {
+    super.setUp()
+    tempDir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("SnapshotCIExportTests-\(UUID().uuidString)")
+    SnapshotCIExportCoordinator.resetShared()
+  }
+
+  override func tearDown() {
+    try? FileManager.default.removeItem(at: tempDir)
+    SnapshotCIExportCoordinator.resetShared()
+    super.tearDown()
+  }
+
+  // MARK: - Shared Instance Gating
+
+  func testSharedIfEnabledReturnsNilWhenEnvVarAbsent() {
+    let coordinator = SnapshotCIExportCoordinator.sharedIfEnabled(environment: [:])
+    XCTAssertNil(coordinator)
+  }
+
+  func testSharedIfEnabledReturnsCoordinatorWhenEnvVarSet() {
+    let coordinator = SnapshotCIExportCoordinator.sharedIfEnabled(
+      environment: [SnapshotCIExportCoordinator.envKey: tempDir.path]
+    )
+    XCTAssertNotNil(coordinator)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.path))
+  }
+
+  func testSharedIfEnabledReturnsSameInstanceOnRepeatedCalls() {
+    let env = [SnapshotCIExportCoordinator.envKey: tempDir.path]
+    let first = SnapshotCIExportCoordinator.sharedIfEnabled(environment: env)
+    let second = SnapshotCIExportCoordinator.sharedIfEnabled(environment: env)
+    XCTAssertTrue(first === second, "Should return the same cached instance")
+  }
+
+  // MARK: - Filename Sanitization
+
+  func testSanitizeReplacesUnsafeCharacters() {
+    let result = SnapshotCIExportCoordinator.sanitize("My/View:Preview 1")
+    let unsafeChars = CharacterSet(charactersIn: "/\\: \"'<>|?*")
+    XCTAssertNil(result.rangeOfCharacter(from: unsafeChars))
+  }
+
+  func testSanitizeIsDeterministic() {
+    let a = SnapshotCIExportCoordinator.sanitize("Some/View:Name")
+    let b = SnapshotCIExportCoordinator.sanitize("Some/View:Name")
+    XCTAssertEqual(a, b)
+  }
+
+  func testSanitizeCollapsesRepeatedUnderscores() {
+    let result = SnapshotCIExportCoordinator.sanitize("A///B___C")
+    XCTAssertFalse(result.contains("__"))
+  }
+
+  func testSanitizeFallsBackForEmptyResult() {
+    let result = SnapshotCIExportCoordinator.sanitize("///")
+    XCTAssertEqual(result, "snapshot")
+  }
+
+  func testSanitizePreservesAlphanumericAndSafeChars() {
+    let result = SnapshotCIExportCoordinator.sanitize("Hello_World-2.0")
+    XCTAssertEqual(result, "Hello_World-2.0")
+  }
+
+  func testResolvedFileNameComponentUsesDisplayNameWhenUnique() {
+    let component = SnapshotTest.resolvedFileNameComponent(
+      fileId: nil,
+      line: nil,
+      previewDisplayName: "Dark Mode",
+      previewIndex: 1,
+      duplicateDisplayNameCount: 1
+    )
+
+    XCTAssertEqual(component, "Dark Mode")
+  }
+
+  func testResolvedFileNameComponentFallsBackToLineForDuplicatePreviewMacroDisplayNames() {
+    let component = SnapshotTest.resolvedFileNameComponent(
+      fileId: "Feature/LoginView.swift",
+      line: 42,
+      previewDisplayName: "Dark Mode",
+      previewIndex: 0,
+      duplicateDisplayNameCount: 2
+    )
+
+    XCTAssertEqual(component, "line-42")
+  }
+
+  func testResolvedFileNameComponentFallsBackToIndexForDuplicatePreviewProviderDisplayNames() {
+    let component = SnapshotTest.resolvedFileNameComponent(
+      fileId: nil,
+      line: nil,
+      previewDisplayName: "Dark Mode",
+      previewIndex: 3,
+      duplicateDisplayNameCount: 2
+    )
+
+    XCTAssertEqual(component, "3")
+  }
+
+  // MARK: - Successful Export
+
+  func testSuccessfulExportWritesPngAndSidecar() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(baseFileName: "TestView_Preview")
+
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    coordinator.drain()
+
+    let sanitized = SnapshotCIExportCoordinator.sanitize(context.baseFileName)
+    let jsonURL = tempDir.appendingPathComponent("\(sanitized).json")
+    let pngURL = tempDir.appendingPathComponent("\(sanitized).png")
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: jsonURL.path))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: pngURL.path))
+  }
+
+  // MARK: - Sidecar Content
+
+  func testSidecarUsesPreviewDisplayNameAndTypeDisplayNameForPreviewProviderPresentation() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(
+      baseFileName: "Login Screen_Dark Mode",
+      typeName: "MyModule.LoginScreen_Previews",
+      typeDisplayName: "Login Screen",
+      previewDisplayName: "Dark Mode"
+    )
+
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+
+    XCTAssertEqual(json["image_file_name"] as? String, SnapshotCIExportCoordinator.sanitize(context.baseFileName))
+    XCTAssertEqual(json["display_name"] as? String, "Dark Mode")
+    XCTAssertEqual(json["group"] as? String, "Login Screen")
+  }
+
+  func testSidecarGroupPrefersFileIdForPreviewMacro() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(
+      baseFileName: "Feature_LoginView.swift_line-42",
+      typeName: "$s7MyApp11LoginViewV13Preview_42fMf_15LLPreviewRegistryMc",
+      typeDisplayName: "Login View",
+      fileId: "Feature/LoginView.swift",
+      line: 42,
+      previewDisplayName: nil
+    )
+
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+
+    XCTAssertEqual(json["group"] as? String, "Feature/LoginView.swift")
+  }
+
+  func testSidecarDisplayNameFallsBackToAtLineForAnonymousPreviewMacroPresentation() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(
+      baseFileName: "Feature_LoginView.swift_line-42",
+      fileId: "Feature/LoginView.swift",
+      line: 42,
+      previewDisplayName: nil
+    )
+
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+
+    XCTAssertEqual(json["display_name"] as? String, "At line #42")
+  }
+
+  func testSidecarDisplayNameFallsBackToIndexForUnnamedPreviewProviderVariantPresentation() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(
+      baseFileName: "TestView_0",
+      fileId: nil,
+      line: nil,
+      previewDisplayName: nil,
+      previewId: "0",
+      previewIndex: 0
+    )
+
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+
+    XCTAssertEqual(json["display_name"] as? String, "0")
+  }
+
+  func testSidecarGroupFallsBackToTypeNameWhenPreviewProviderDisplayNameUnavailable() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(
+      baseFileName: "MyModule.TestView_Previews_0",
+      typeName: "MyModule.TestView_Previews",
+      typeDisplayName: "",
+      fileId: nil,
+      line: nil,
+      previewDisplayName: nil
+    )
+
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+
+    XCTAssertEqual(json["group"] as? String, "MyModule.TestView_Previews")
+  }
+
+  func testSidecarFlattensContextFields() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(
+      baseFileName: "TestView_Preview",
+      line: 99,
+      previewId: "7",
+      colorScheme: "dark"
+    )
+
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+
+    XCTAssertEqual(json["typeName"] as? String, context.typeName)
+    XCTAssertEqual(json["orientation"] as? String, "portrait")
+    XCTAssertEqual(json["previewId"] as? String, "7")
+    XCTAssertEqual(json["line"] as? Int, 99)
+    XCTAssertEqual(json["colorScheme"] as? String, "dark")
+    XCTAssertNil(json["context"])
+  }
+
+  // MARK: - Render Failure
+
+  func testRenderFailureProducesNoFiles() {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(baseFileName: "TestView_Preview")
+
+    coordinator.enqueueExport(result: makeFailureResult(), context: context)
+    coordinator.drain()
+
+    let sanitized = SnapshotCIExportCoordinator.sanitize(context.baseFileName)
+    XCTAssertFalse(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(sanitized).png").path))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(sanitized).json").path))
+  }
+
+  // MARK: - Drain Semantics
+
+  func testDrainIsIdempotent() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(baseFileName: "TestView_Preview")
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+
+    coordinator.drain()
+    coordinator.drain()
+
+    let sanitized = SnapshotCIExportCoordinator.sanitize(context.baseFileName)
+    XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(sanitized).json").path))
+  }
+
+  func testDrainOnEmptyQueueDoesNotCrash() {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    coordinator.drain()
+  }
+
+  // MARK: - Multiple Exports
+
+  func testMultipleExportsProduceIndividualFiles() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+
+    let contexts = (0..<5).map { i in
+      makeContext(
+        baseFileName: "View\(i)_Preview",
+        typeName: "Module.View\(i)",
+        previewId: "\(i)",
+        previewIndex: i
+      )
+    }
+
+    for context in contexts {
+      coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    }
+    coordinator.drain()
+
+    for context in contexts {
+      let sanitized = SnapshotCIExportCoordinator.sanitize(context.baseFileName)
+      XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(sanitized).png").path))
+      XCTAssertTrue(FileManager.default.fileExists(atPath: tempDir.appendingPathComponent("\(sanitized).json").path))
+    }
+  }
+}
+
+// MARK: - Test Helpers
+
+extension SnapshotCIExportCoordinatorTests {
+
+  private func readJSON(forBaseFileName baseFileName: String) throws -> [String: Any] {
+    let sanitized = SnapshotCIExportCoordinator.sanitize(baseFileName)
+    let data = try Data(contentsOf: tempDir.appendingPathComponent("\(sanitized).json"))
+    return try JSONSerialization.jsonObject(with: data) as! [String: Any]
+  }
+
+  private func makeContext(
+    baseFileName: String,
+    typeName: String = "MyModule.TestView_Previews",
+    typeDisplayName: String = "Test View",
+    fileId: String? = nil,
+    line: Int? = nil,
+    previewDisplayName: String? = "Preview",
+    previewId: String = "0",
+    previewIndex: Int = 0,
+    colorScheme: String? = nil
+  ) -> SnapshotContext {
+    SnapshotContext(
+      baseFileName: baseFileName,
+      testName: "-[MyTests testPreview]",
+      typeName: typeName,
+      typeDisplayName: typeDisplayName,
+      fileId: fileId,
+      line: line,
+      previewDisplayName: previewDisplayName,
+      previewIndex: previewIndex,
+      previewId: previewId,
+      orientation: "portrait",
+      declaredDevice: nil,
+      simulatorDeviceName: nil,
+      simulatorModelIdentifier: nil,
+      precision: nil,
+      accessibilityEnabled: nil,
+      colorScheme: colorScheme,
+      appStoreSnapshot: nil
+    )
+  }
+
+  private func makeTestImage() -> ImageType {
+    #if canImport(UIKit)
+    let renderer = UIGraphicsImageRenderer(size: CGSize(width: 1, height: 1))
+    return renderer.image { ctx in
+      UIColor.red.setFill()
+      ctx.fill(CGRect(x: 0, y: 0, width: 1, height: 1))
+    }
+    #else
+    let rep = NSBitmapImageRep(
+      bitmapDataPlanes: nil,
+      pixelsWide: 1,
+      pixelsHigh: 1,
+      bitsPerSample: 8,
+      samplesPerPixel: 4,
+      hasAlpha: true,
+      isPlanar: false,
+      colorSpaceName: .deviceRGB,
+      bytesPerRow: 0,
+      bitsPerPixel: 0
+    )!
+    let image = NSImage(size: NSSize(width: 1, height: 1))
+    image.addRepresentation(rep)
+    return image
+    #endif
+  }
+
+  private func makeSuccessResult() -> SnapshotResult {
+    SnapshotResult(
+      image: .success(makeTestImage()),
+      precision: nil,
+      accessibilityEnabled: nil,
+      colorScheme: nil,
+      appStoreSnapshot: nil
+    )
+  }
+
+  private func makeFailureResult() -> SnapshotResult {
+    SnapshotResult(
+      image: .failure(NSError(domain: "test", code: 1)),
+      precision: nil,
+      accessibilityEnabled: nil,
+      colorScheme: nil,
+      appStoreSnapshot: nil
+    )
+  }
+}


### PR DESCRIPTION
This branch adds filesystem-based snapshot export for CI flows and makes exported snapshot naming and metadata deterministic across the preview scenarios we cover.

## Summary

- Adds an env-var-gated CI export path via `SNAPSHOTS_EXPORT_DIR`
- Writes snapshot PNGs plus flattened JSON sidecars through `SnapshotCIExportCoordinator`
- Uses shared canonical rules for exported `group` and `display_name` metadata
- Sanitizes snapshot `baseFileName` at construction time so attachments and exports use the same stable names
- Skips oversized snapshot exports above the 40M pixel limit before writing PNGs that the upload CLI would reject

## Naming and metadata behavior

Filename and sidecar naming now cover the main preview cases explicitly:

- Unique named previews keep their display name in the filename
- Duplicate preview display names within the same canonical group fall back to a disambiguator
- Preview macros fall back to `line-<n>` when needed
- Unnamed `PreviewProvider` variants fall back to the preview index
- Exported `group` resolves as `fileId -> typeDisplayName -> typeName`
- Exported `display_name` resolves as explicit preview display name -> `At line #N` -> preview index

## Artifacts:

Images and sidecar files from HackerNews local run:
[HackerNewsSnapshots.zip](https://github.com/user-attachments/files/26534559/HackerNewsSnapshots.zip)

Latest workflow run https://github.com/EmergeTools/hackernews/actions/runs/23940370307/job/69825189739?pr=780
Sentry Snapshots Viewer: https://sentry.sentry.io/preprod/snapshots/180875/

### Example

HackerNews_FeedScreen.swift_161_Has_posts.png:

<img width="300" alt="HackerNews_FeedScreen swift_161_Has_posts" src="https://github.com/user-attachments/assets/bd78274b-2a69-4025-809b-d60dc734ea1a" />

HackerNews_FeedScreen.swift_161_Has_posts.json:

```json
{
  "baseFileName" : "HackerNews_FeedScreen.swift_161_Has_posts",
  "display_name" : "Has posts",
  "fileId" : "HackerNews\/FeedScreen.swift",
  "group" : "HackerNews\/FeedScreen.swift",
  "image_file_name" : "HackerNews_FeedScreen.swift_161_Has_posts",
  "line" : 161,
  "orientation" : "portrait",
  "previewDisplayName" : "Has posts",
  "previewId" : "0",
  "previewIndex" : 0,
  "simulatorDeviceName" : "iPhone 17 Pro Max",
  "simulatorModelIdentifier" : "iPhone18,2",
  "testName" : "-[HackerNewsSnapshotTest portrait-Feed Screen-0-19]",
  "typeDisplayName" : "Feed Screen",
  "typeName" : "HackerNews.$s10HackerNews0021FeedScreenswift_IfFDefMX160_0_33_2B34B1DE919BF62EDDE40FEC34EF23D3Ll7PreviewfMf2_15PreviewRegistryfMu_"
}
```

Same snapshot in Sentry UI:

<img width="600" alt="Screenshot 2026-04-07 at 11 45 52" src="https://github.com/user-attachments/assets/306d6f54-429a-4817-a3dc-c735cd6a53f0" />

## Testing

Run tests with `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR` set:

```
 TEST_RUNNER_SNAPSHOTS_EXPORT_DIR=/tmp/snapshots \
  xcodebuild test \
    -scheme DemoAppTests \
    -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'
```

View files
```
ls -la /tmp/snapshots
```

Upload to Sentry
```
sentry build snapshots \
    --app-id "snapshots-test" \
    --head-sha "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
    --base-sha "0000000000000000000000000000000000000000" \
    --head-ref "main" \
    --base-ref "main" \
    --head-repo-name "getsentry/SnapshotPreviewsTest" \
    --base-repo-name "getsentry/SnapshotPreviewsTest" \
    --vcs-provider "github" \
    --force-git-metadata \
    /tmp/snapshots
```

## Linear

[EME-931](https://linear.app/getsentry/issue/EME-931/ios-create-snapshotpreviews-lib-wrapper-for-preview-image-extraction)