### PR TITLE
ref(snapshotting): Centralize preview filename resolution

### DIFF
--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -164,6 +164,14 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
     return typeName
   }
 
+  static func canonicalGroup(for previewType: SnapshotPreviewsCore.PreviewType) -> String {
+    canonicalGroup(
+      fileId: previewType.fileID,
+      typeDisplayName: previewType.displayName,
+      typeName: previewType.typeName
+    )
+  }
+
   private static func canonicalDisplayName(for context: SnapshotContext) -> String {
     if let previewDisplayName = context.previewDisplayName, !previewDisplayName.isEmpty {
       return previewDisplayName

--- a/Sources/SnapshottingTests/SnapshotTest.swift
+++ b/Sources/SnapshottingTests/SnapshotTest.swift
@@ -28,7 +28,141 @@ extension ColorScheme {
 /// This class is designed to discover SwiftUI previews, render them, and generate snapshot images for testing purposes.
 /// It provides mechanisms for filtering previews and supports different rendering strategies based on the platform.
 open class SnapshotTest: PreviewBaseTest, PreviewFilters {
-  
+
+  private struct FileNameKey: Hashable {
+    let typeName: String
+    let previewIndex: Int
+  }
+
+  struct FileNameResolver {
+    private typealias PreviewGroup = String
+    private typealias PreviewDisplayName = String
+
+    private struct DuplicateKey: Hashable {
+      let group: PreviewGroup
+      let displayName: PreviewDisplayName
+    }
+
+    private struct PreviewMeta {
+      let previewType: SnapshotPreviewsCore.PreviewType
+      let group: PreviewGroup
+      let prefix: String
+    }
+
+    private let rawBaseFileNameByKey: [FileNameKey: String]
+
+    init(previews: [SnapshotPreviewsCore.PreviewType]) {
+      let metas = previews.map { previewType in
+        PreviewMeta(
+          previewType: previewType,
+          group: SnapshotCIExportCoordinator.canonicalGroup(for: previewType),
+          prefix: Self.fileNamePrefix(typeDisplayName: previewType.displayName, fileId: previewType.fileID)
+        )
+      }
+
+      // First pass: count previews sharing each (group, displayName) to detect
+      // duplicates that need disambiguation.
+      var displayNameCountByGroup: [PreviewGroup: [PreviewDisplayName: Int]] = [:]
+      for meta in metas {
+        for preview in meta.previewType.previews {
+          guard let displayName = preview.displayName, !displayName.isEmpty else { continue }
+          displayNameCountByGroup[meta.group, default: [:]][displayName, default: 0] += 1
+        }
+      }
+
+      // Second pass: assign a 1-based ordinal to each duplicate occurrence and
+      // build the raw base file name for every preview.
+      var nextOrdinalByKey: [DuplicateKey: Int] = [:]
+      var rawBaseFileNameByKey: [FileNameKey: String] = [:]
+
+      for meta in metas {
+        let displayNameCounts = displayNameCountByGroup[meta.group] ?? [:]
+
+        for (previewIndex, preview) in meta.previewType.previews.enumerated() {
+          let occurrenceCount = preview.displayName.flatMap { displayNameCounts[$0] } ?? 0
+
+          var ordinal: Int?
+          if let displayName = preview.displayName, occurrenceCount > 1 {
+            let ordinalKey = DuplicateKey(group: meta.group, displayName: displayName)
+            let next = nextOrdinalByKey[ordinalKey, default: 1]
+            nextOrdinalByKey[ordinalKey] = next + 1
+            ordinal = next
+          }
+
+          let component = Self.fileNameComponent(
+            previewDisplayName: preview.displayName,
+            previewIndex: previewIndex,
+            fileId: meta.previewType.fileID,
+            line: meta.previewType.line,
+            displayNameOccurrenceCount: occurrenceCount,
+            duplicateDisplayNameOrdinal: ordinal
+          )
+
+          let key = FileNameKey(typeName: meta.previewType.typeName, previewIndex: previewIndex)
+          rawBaseFileNameByKey[key] = "\(meta.prefix)_\(component)"
+        }
+      }
+
+      self.rawBaseFileNameByKey = rawBaseFileNameByKey
+    }
+
+    func rawBaseFileName(typeName: String, previewIndex: Int) -> String? {
+      rawBaseFileNameByKey[FileNameKey(typeName: typeName, previewIndex: previewIndex)]
+    }
+
+    static func rawBaseFileName(
+      typeDisplayName: String,
+      fileId: String?,
+      previewDisplayName: String?,
+      previewIndex: Int,
+      line: Int?,
+      displayNameOccurrenceCount: Int,
+      duplicateDisplayNameOrdinal: Int?
+    ) -> String {
+      let prefix = fileNamePrefix(typeDisplayName: typeDisplayName, fileId: fileId)
+      let component = fileNameComponent(
+        previewDisplayName: previewDisplayName,
+        previewIndex: previewIndex,
+        fileId: fileId,
+        line: line,
+        displayNameOccurrenceCount: displayNameOccurrenceCount,
+        duplicateDisplayNameOrdinal: duplicateDisplayNameOrdinal
+      )
+      return "\(prefix)_\(component)"
+    }
+
+    private static func fileNamePrefix(typeDisplayName: String, fileId: String?) -> String {
+      if let fileId, !fileId.isEmpty {
+        return fileId
+      }
+      return typeDisplayName
+    }
+
+    private static func fileNameComponent(
+      previewDisplayName: String?,
+      previewIndex: Int,
+      fileId: String?,
+      line: Int?,
+      displayNameOccurrenceCount: Int,
+      duplicateDisplayNameOrdinal: Int?
+    ) -> String {
+      if let previewDisplayName, !previewDisplayName.isEmpty {
+        if displayNameOccurrenceCount <= 1 {
+          return previewDisplayName
+        }
+        if let duplicateDisplayNameOrdinal {
+          return "\(previewDisplayName)_\(duplicateDisplayNameOrdinal)"
+        }
+      }
+
+      if fileId != nil, let line {
+        return "line-\(line)"
+      }
+
+      return String(previewIndex)
+    }
+  }
+
   /// Returns an optional array of preview names to be included in the snapshot testing. This also supports Regex format.
   ///
   /// Override this method to specify which previews should be included in the snapshot test.
@@ -76,54 +210,14 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
   @MainActor private static var ciExportCoordinator: SnapshotCIExportCoordinator?
 
   static private var previews: [SnapshotPreviewsCore.PreviewType] = []
-
-  static private var previewCountForFileId: [String: Int] = [:]
-  static private var previewDisplayNameCountByGroup: [String: [String: Int]] = [:]
-
-  static func resolvedFileNameComponent(
-    fileId: String?,
-    line: Int?,
-    previewDisplayName: String?,
-    previewIndex: Int,
-    duplicateDisplayNameCount: Int
-  ) -> String {
-    if let previewDisplayName, !previewDisplayName.isEmpty, duplicateDisplayNameCount <= 1 {
-      return previewDisplayName
-    }
-
-    if let fileId, !fileId.isEmpty, let line {
-      return "line-\(line)"
-    }
-
-    return String(previewIndex)
-  }
+  static private var fileNameResolver = FileNameResolver(previews: [])
 
   @MainActor
   override class func discoverPreviews() -> [DiscoveredPreview] {
     ciExportCoordinator = SnapshotCIExportCoordinator.createFromEnvironment()
 
     previews = FindPreviews.findPreviews(included: Self.snapshotPreviews(), excluded: Self.excludedSnapshotPreviews())
-    previewCountForFileId = [:]
-    previewDisplayNameCountByGroup = [:]
-
-    for previewType in previews {
-      if let fileId = previewType.fileID {
-        previewCountForFileId[fileId, default: 0] += 1
-      }
-
-      let group = SnapshotCIExportCoordinator.canonicalGroup(
-        fileId: previewType.fileID,
-        typeDisplayName: previewType.displayName,
-        typeName: previewType.typeName
-      )
-      for preview in previewType.previews {
-        guard let previewDisplayName = preview.displayName, !previewDisplayName.isEmpty else {
-          continue
-        }
-        previewDisplayNameCountByGroup[group, default: [:]][previewDisplayName, default: 0] += 1
-      }
-    }
-
+    fileNameResolver = FileNameResolver(previews: previews)
     return previews.map { DiscoveredPreview.from(previewType: $0) }
   }
 
@@ -155,11 +249,6 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
       Self.renderingStrategy = strategy
     }
 
-    var typeFileName = previewType.displayName
-    if let fileId = previewType.fileID, let lineNumber = previewType.line {
-      typeFileName = Self.previewCountForFileId[fileId]! > 1 ? "\(fileId):\(lineNumber)" : fileId
-    }
-
     var result: SnapshotResult? = nil
     let expectation = XCTestExpectation()
     strategy.render(preview: preview) { snapshotResult in
@@ -172,24 +261,15 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
       return
     }
 
-    let previewGroup = SnapshotCIExportCoordinator.canonicalGroup(
-      fileId: previewType.fileID,
-      typeDisplayName: previewType.displayName,
-      typeName: previewType.typeName
-    )
-    let duplicateDisplayNameCount = preview.displayName.flatMap {
-      Self.previewDisplayNameCountByGroup[previewGroup]?[$0]
-    } ?? 0
-    let fileNameComponent = Self.resolvedFileNameComponent(
-      fileId: previewType.fileID,
-      line: previewType.line,
-      previewDisplayName: preview.displayName,
-      previewIndex: discoveredPreview.index,
-      duplicateDisplayNameCount: duplicateDisplayNameCount
-    )
-    let baseFileName = SnapshotCIExportCoordinator.sanitize(
-      "\(typeFileName)_\(fileNameComponent)"
-    )
+    guard let rawBaseFileName = Self.fileNameResolver.rawBaseFileName(
+      typeName: previewType.typeName,
+      previewIndex: discoveredPreview.index
+    ) else {
+      XCTFail("Preview file name not found")
+      return
+    }
+
+    let baseFileName = SnapshotCIExportCoordinator.sanitize(rawBaseFileName)
     if let coordinator = Self.ciExportCoordinator {
       let colorSchemeValue = result.colorScheme?.stringValue
       let context = SnapshotContext(

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -79,40 +79,99 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     XCTAssertEqual(result, "Hello_World-2.0")
   }
 
-  func testResolvedFileNameComponentUsesDisplayNameWhenUnique() {
-    let component = SnapshotTest.resolvedFileNameComponent(
-      fileId: nil,
-      line: nil,
+  func testRawBaseFileNameUsesDisplayNameWhenUniqueForPreviewProvider() {
+    let fileName = makeRawBaseFileName(
       previewDisplayName: "Dark Mode",
-      previewIndex: 1,
-      duplicateDisplayNameCount: 1
+      displayNameOccurrenceCount: 1
     )
 
-    XCTAssertEqual(component, "Dark Mode")
+    XCTAssertEqual(fileName, "Test View_Dark Mode")
   }
 
-  func testResolvedFileNameComponentFallsBackToLineForDuplicatePreviewMacroDisplayNames() {
-    let component = SnapshotTest.resolvedFileNameComponent(
-      fileId: "Feature/LoginView.swift",
-      line: 42,
-      previewDisplayName: "Dark Mode",
-      previewIndex: 0,
-      duplicateDisplayNameCount: 2
-    )
+  func testRawBaseFileNameFallsBackToIndexForUnnamedPreviewProvider() {
+    let fileName = makeRawBaseFileName()
 
-    XCTAssertEqual(component, "line-42")
+    XCTAssertEqual(fileName, "Test View_0")
   }
 
-  func testResolvedFileNameComponentFallsBackToIndexForDuplicatePreviewProviderDisplayNames() {
-    let component = SnapshotTest.resolvedFileNameComponent(
-      fileId: nil,
-      line: nil,
+  func testRawBaseFileNameUsesDisplayNameOrdinalForDuplicatePreviewProviderDisplayNames() {
+    let fileName = makeRawBaseFileName(
       previewDisplayName: "Dark Mode",
       previewIndex: 3,
-      duplicateDisplayNameCount: 2
+      displayNameOccurrenceCount: 2,
+      duplicateDisplayNameOrdinal: 1
     )
 
-    XCTAssertEqual(component, "3")
+    XCTAssertEqual(fileName, "Test View_Dark Mode_1")
+  }
+
+  func testRawBaseFileNameUsesDisplayNameForSinglePreviewMacro() {
+    let fileName = makeRawBaseFileName(
+      typeDisplayName: "Login View",
+      fileId: "Feature/LoginView.swift",
+      previewDisplayName: "Dark Mode",
+      line: 42,
+      displayNameOccurrenceCount: 1
+    )
+
+    XCTAssertEqual(fileName, "Feature/LoginView.swift_Dark Mode")
+  }
+
+  func testRawBaseFileNameFallsBackToLineForAnonymousSinglePreviewMacro() {
+    let fileName = makeRawBaseFileName(
+      typeDisplayName: "Login View",
+      fileId: "Feature/LoginView.swift",
+      line: 42
+    )
+
+    XCTAssertEqual(fileName, "Feature/LoginView.swift_line-42")
+  }
+
+  func testRawBaseFileNameUsesDisplayNameForMultiPreviewMacro() {
+    let fileName = makeRawBaseFileName(
+      typeDisplayName: "Login View",
+      fileId: "Feature/LoginView.swift",
+      previewDisplayName: "Dark Mode",
+      line: 42,
+      displayNameOccurrenceCount: 1
+    )
+
+    XCTAssertEqual(fileName, "Feature/LoginView.swift_Dark Mode")
+  }
+
+  func testRawBaseFileNameFallsBackToLineForAnonymousMultiPreviewMacro() {
+    let fileName = makeRawBaseFileName(
+      typeDisplayName: "Login View",
+      fileId: "Feature/LoginView.swift",
+      line: 42
+    )
+
+    XCTAssertEqual(fileName, "Feature/LoginView.swift_line-42")
+  }
+
+  func testRawBaseFileNameUsesDisplayNameOrdinalForDuplicateNamedMultiPreviewMacro() {
+    let fileName = makeRawBaseFileName(
+      typeDisplayName: "Login View",
+      fileId: "Feature/LoginView.swift",
+      previewDisplayName: "Dark Mode",
+      line: 42,
+      displayNameOccurrenceCount: 2,
+      duplicateDisplayNameOrdinal: 1
+    )
+
+    XCTAssertEqual(fileName, "Feature/LoginView.swift_Dark Mode_1")
+  }
+
+  func testRawBaseFileNameFallsBackToLineWhenDuplicateNamedMultiPreviewMacroOrdinalMissing() {
+    let fileName = makeRawBaseFileName(
+      typeDisplayName: "Login View",
+      fileId: "Feature/LoginView.swift",
+      previewDisplayName: "Dark Mode",
+      line: 42,
+      displayNameOccurrenceCount: 2
+    )
+
+    XCTAssertEqual(fileName, "Feature/LoginView.swift_line-42")
   }
 
   // MARK: - Successful Export
@@ -312,6 +371,26 @@ extension SnapshotCIExportCoordinatorTests {
   private func readJSON(forBaseFileName baseFileName: String) throws -> [String: Any] {
     let data = try Data(contentsOf: tempDir.appendingPathComponent("\(baseFileName).json"))
     return try JSONSerialization.jsonObject(with: data) as! [String: Any]
+  }
+
+  private func makeRawBaseFileName(
+    typeDisplayName: String = "Test View",
+    fileId: String? = nil,
+    previewDisplayName: String? = nil,
+    previewIndex: Int = 0,
+    line: Int? = nil,
+    displayNameOccurrenceCount: Int = 0,
+    duplicateDisplayNameOrdinal: Int? = nil
+  ) -> String {
+    SnapshotTest.FileNameResolver.rawBaseFileName(
+      typeDisplayName: typeDisplayName,
+      fileId: fileId,
+      previewDisplayName: previewDisplayName,
+      previewIndex: previewIndex,
+      line: line,
+      displayNameOccurrenceCount: displayNameOccurrenceCount,
+      duplicateDisplayNameOrdinal: duplicateDisplayNameOrdinal
+    )
   }
 
   private func makeContext(


### PR DESCRIPTION
Centralize snapshot export filename resolution behind a single resolver and simplify the filename policy used by `SnapshotTest`.

The previous logic was split across discovery-time metadata maps, runtime assembly in `testPreview`, and several fallback branches. That made the code harder to reason about and also produced unstable filenames in cases where a display name was already enough to identify the preview.

This change moves filename generation into `SnapshotTest.FileNameResolver`, computes names once during preview discovery, and makes the runtime path a simple lookup.

Behavior changes:
- Named `#Preview`s now prefer `fileId + displayName`
- Duplicate named previews now use `displayName_ordinal`
- Anonymous macro previews fall back to `line-<line>`
- Anonymous provider previews still fall back to `previewIndex`
- Duplicate line information is no longer emitted in filenames

Before / after examples:
- Before: `HackerNews_CommentRow.swift_152_HTML_case_1.png`
- After: `HackerNews_CommentRow.swift_HTML_case_1.png`

- Before: `Feature_LoginView.swift_42_line-42.png`
- After: `Feature_LoginView.swift_line-42.png`

- Before: duplicate named provider previews could fall back to raw indexes such as `Test_View_3`
- After: they resolve to display-name ordinals such as `Test_View_Dark_Mode_1`

I also renamed the internal count from `duplicateDisplayNameCount` to `displayNameOccurrenceCount` and added typealiases for the resolver's string-backed grouping concepts so the code reads closer to what it is actually modeling.

Validated with `swift test --filter SnapshottingTestsTests` and `swift test`.