### PR TITLE
feat(snapshotting): Add test_file_path to sidecars

### DIFF
--- a/Examples/DemoApp/Demo Watch AppTests/DemoWatchSnapshotTest.swift
+++ b/Examples/DemoApp/Demo Watch AppTests/DemoWatchSnapshotTest.swift
@@ -9,5 +9,5 @@ import Foundation
 import SnapshottingTests
 
 final class DemoWatchSnapshotTest: SnapshotTest {
-  
+  override class var testFilePath: String? { #filePath }
 }

--- a/Examples/DemoApp/DemoAppTests/DemoAppSnapshotTest.swift
+++ b/Examples/DemoApp/DemoAppTests/DemoAppSnapshotTest.swift
@@ -13,6 +13,8 @@ import SnapshottingTests
 import AccessibilitySnapshotCore
 
 class DemoAppSnapshotTest: SnapshotTest {
+  override class var testFilePath: String? { #filePath }
+
   override class func snapshotPreviews() -> [String]? {
     return nil
   }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Generate PNGs for each Xcode preview with no code as part of an XCTest. Link you
 import SnapshottingTests
 
 class DemoAppPreviewTest: SnapshotTest {
+  override class var testFilePath: String? { #filePath }
 
   // Return the type names of previews like "MyApp.MyView._Previews" to selectively render only some previews
   override class func snapshotPreviews() -> [String]? {

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -39,11 +39,13 @@ private struct SnapshotCIExportSidecar: Sendable, Encodable {
   let imageFileName: String
   let displayName: String
   let group: String
+  let testFilePath: String?
 
   private enum ExtraKeys: String, CodingKey {
     case image_file_name
     case display_name
     case group
+    case test_file_path
   }
 
   func encode(to encoder: Encoder) throws {
@@ -52,6 +54,7 @@ private struct SnapshotCIExportSidecar: Sendable, Encodable {
     try container.encode(imageFileName, forKey: .image_file_name)
     try container.encode(displayName, forKey: .display_name)
     try container.encode(group, forKey: .group)
+    try container.encode(testFilePath, forKey: .test_file_path)
   }
 }
 
@@ -164,6 +167,36 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
     return typeName
   }
 
+  static func relativeTestFilePath(
+    _ testFilePath: String?,
+    fileManager: FileManager = .default
+  ) -> String? {
+    guard let testFilePath, !testFilePath.isEmpty else {
+      return nil
+    }
+
+    let fileURL = URL(fileURLWithPath: testFilePath).standardizedFileURL
+    var searchURL = fileURL.deletingLastPathComponent()
+
+    while searchURL.path != searchURL.deletingLastPathComponent().path {
+      let gitURL = searchURL.appendingPathComponent(".git")
+      if fileManager.fileExists(atPath: gitURL.path) {
+        let rootPath = searchURL.path
+        guard fileURL.path.hasPrefix(rootPath) else {
+          return testFilePath
+        }
+
+        let relativePath = String(fileURL.path.dropFirst(rootPath.count))
+          .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return relativePath.isEmpty ? fileURL.lastPathComponent : relativePath
+      }
+
+      searchURL = searchURL.deletingLastPathComponent()
+    }
+
+    return testFilePath
+  }
+
   private static func canonicalDisplayName(for context: SnapshotContext) -> String {
     if let previewDisplayName = context.previewDisplayName, !previewDisplayName.isEmpty {
       return previewDisplayName
@@ -180,9 +213,15 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
   ///
   /// PNG encoding and file writes are dispatched to a concurrent background queue
   /// so the calling test can proceed to the next preview immediately.
+  ///
+  /// - Parameter testFilePath: Absolute source path of the XCTest subclass that
+  ///   produced this snapshot. This is normalized to a path relative to the
+  ///   enclosing Git repository root and emitted under the `test_file_path` key
+  ///   in the sidecar. Pass `nil` when the originating test does not supply one.
   func enqueueExport(
     result: SnapshotResult,
-    context: SnapshotContext
+    context: SnapshotContext,
+    testFilePath: String? = nil
   ) {
     let pngFileName = "\(context.baseFileName).png"
     let jsonFileName = "\(context.baseFileName).json"
@@ -193,6 +232,7 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
       typeDisplayName: context.typeDisplayName,
       typeName: context.typeName
     )
+    let normalizedTestFilePath = Self.relativeTestFilePath(testFilePath, fileManager: fileManager)
     let exportDir = exportDirectoryURL
     
     guard case .success(let image) = result.image else { return }
@@ -214,7 +254,8 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
         context: context,
         imageFileName: context.baseFileName,
         displayName: displayName,
-        group: group
+        group: group,
+        testFilePath: normalizedTestFilePath
       )
 
       let jsonURL = exportDir.appendingPathComponent(jsonFileName)

--- a/Sources/SnapshottingTests/SnapshotTest.swift
+++ b/Sources/SnapshottingTests/SnapshotTest.swift
@@ -51,6 +51,24 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
   }
   #endif
 
+  /// Absolute source path of the XCTest subclass, normalized to a repo-relative
+  /// path and recorded in the sidecar metadata under the `test_file_path` key
+  /// during CI export.
+  ///
+  /// The Swift runtime does not expose the source file for a class, so callers
+  /// must opt in from their own `.swift` file. Override in each `SnapshotTest`
+  /// subclass and return `#filePath` so the compiler captures the path at the
+  /// override site:
+  ///
+  /// ```swift
+  /// final class MySnapshotTest: SnapshotTest {
+  ///   override class var testFilePath: String? { #filePath }
+  /// }
+  /// ```
+  ///
+  /// Defaults to `nil`, which causes the sidecar to emit `test_file_path: null`.
+  open class var testFilePath: String? { nil }
+
   /// Determines the appropriate rendering strategy based on the current platform and OS version.
   ///
   /// This method selects between UIKit, AppKit, and SwiftUI rendering strategies depending on the available frameworks and OS version.
@@ -210,7 +228,11 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
         accessibilityEnabled: result.accessibilityEnabled,
         colorScheme: colorSchemeValue,
         appStoreSnapshot: result.appStoreSnapshot)
-      coordinator.enqueueExport(result: result, context: context)
+      coordinator.enqueueExport(
+        result: result,
+        context: context,
+        testFilePath: Self.testFilePath
+      )
     } else {
       do {
         let attachment = try XCTAttachment(image: result.image.get())

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -248,6 +248,42 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     XCTAssertNil(json["context"])
   }
 
+  func testSidecarWritesTestFilePathWhenProvided() throws {
+    let repoRoot = tempDir.appendingPathComponent("Repo", isDirectory: true)
+    let gitDir = repoRoot.appendingPathComponent(".git", isDirectory: true)
+    let testsDir = repoRoot.appendingPathComponent("Tests", isDirectory: true)
+    try FileManager.default.createDirectory(at: gitDir, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: testsDir, withIntermediateDirectories: true)
+
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(baseFileName: "TestView_Preview")
+    let testFilePath = testsDir.appendingPathComponent("DemoAppSnapshotTest.swift").path
+
+    coordinator.enqueueExport(
+      result: makeSuccessResult(),
+      context: context,
+      testFilePath: testFilePath
+    )
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+
+    XCTAssertEqual(json["test_file_path"] as? String, "Tests/DemoAppSnapshotTest.swift")
+  }
+
+  func testSidecarEmitsNullTestFilePathWhenAbsent() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(baseFileName: "TestView_Preview")
+
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+
+    XCTAssertTrue(json.keys.contains("test_file_path"))
+    XCTAssertTrue(json["test_file_path"] is NSNull)
+  }
+
   // MARK: - Render Failure
 
   func testRenderFailureProducesNoFiles() {


### PR DESCRIPTION
Add `test_file_path` to exported snapshot sidecar metadata.

This change adds an explicit `SnapshotTest.testFilePath` override point so snapshot tests can opt in to reporting the source file of the XCTest subclass that produced the snapshot. Swift does not expose the declaring source file for a class at runtime, so the path has to be captured explicitly with `#filePath` at the subclass declaration site.

The export coordinator writes that value under the new `test_file_path` key in the sidecar JSON. Before writing, it walks upward from the supplied absolute path until it finds the enclosing `.git` directory and then strips that repo root prefix, so the stored value is stable across machines and CI workers.

Example:
- captured from the test subclass: `/Users/someuser/code/SnapshotPreviews/Examples/DemoApp/DemoAppTests/DemoAppSnapshotTest.swift`
- written to the sidecar: `Examples/DemoApp/DemoAppTests/DemoAppSnapshotTest.swift`

If no repo root is found, the coordinator falls back to the original path.

Refs EME-1050