### PR TITLE
ref(snapshotting): encode snapshot sidecar metadata in snake_case

### DIFF
--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -220,6 +220,7 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
       let jsonURL = exportDir.appendingPathComponent(jsonFileName)
       do {
         let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(sidecar)
         try data.write(to: jsonURL, options: .atomic)

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -240,11 +240,11 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
 
     let json = try readJSON(forBaseFileName: context.baseFileName)
 
-    XCTAssertEqual(json["typeName"] as? String, context.typeName)
+    XCTAssertEqual(json["type_name"] as? String, context.typeName)
     XCTAssertEqual(json["orientation"] as? String, "portrait")
-    XCTAssertEqual(json["previewId"] as? String, "7")
+    XCTAssertEqual(json["preview_id"] as? String, "7")
     XCTAssertEqual(json["line"] as? Int, 99)
-    XCTAssertEqual(json["colorScheme"] as? String, "dark")
+    XCTAssertEqual(json["color_scheme"] as? String, "dark")
     XCTAssertNil(json["context"])
   }
 


### PR DESCRIPTION
Encode snapshot sidecar metadata in snake_case.

This updates the snapshot sidecar JSON produced during export so context fields are written as snake_case keys such as `diff_threshold`, `type_display_name`, and `preview_id`.

The sidecar encoding now uses `JSONEncoder.KeyEncodingStrategy.convertToSnakeCase` for `SnapshotContext`.

Refs EME-1053