### PR TITLE
feat(snapshotting): add diffThreshold preview modifier

### DIFF
--- a/Examples/DemoApp/DemoApp/TestViews/RideShareButton.swift
+++ b/Examples/DemoApp/DemoApp/TestViews/RideShareButton.swift
@@ -35,7 +35,7 @@ struct RideShareButtonView_Previews: PreviewProvider {
         .padding()
         .previewDisplayName("Ride Share Button View - Light")
         // This should never show as a diff
-        .emergeSnapshotPrecision(0.0)
+        .diffThreshold(1.0)
       #if os(iOS)
         .emergeRenderingMode(.coreAnimation)
       #endif

--- a/Examples/DemoApp/DemoModule/HomeMapView.swift
+++ b/Examples/DemoApp/DemoModule/HomeMapView.swift
@@ -46,6 +46,6 @@ struct HomeMapView: View {
 struct HomeMapView_Previews: PreviewProvider {
     static var previews: some View {
         HomeMapView(address: "123 Main St, San Francisco, CA")
-        .emergeSnapshotPrecision(0.9)
+        .diffThreshold(0.1)
     }
 }

--- a/Sources/SnapshotPreferences/DiffThresholdPreference.swift
+++ b/Sources/SnapshotPreferences/DiffThresholdPreference.swift
@@ -1,0 +1,35 @@
+//
+//  DiffThresholdPreference.swift
+//
+//
+//  Created by Cameron Cooke on 4/20/26.
+//
+
+import Foundation
+import SwiftUI
+
+extension View {
+    /// Sets the allowed diff threshold for the snapshot on the view.
+    ///
+    /// Use this method to control how much difference is tolerated when comparing snapshots.
+    /// With a diff threshold of `0.0`, snapshots must match exactly. With a diff threshold of
+    /// `1.0`, the snapshot will never be flagged for having differences.
+    ///
+    /// - Parameter diffThreshold: A Float value representing the allowed diff threshold for
+    ///   snapshot comparison. If `nil`, the default behavior is used.
+    ///
+    /// - Returns: A view with the snapshot diff threshold preference applied.
+    ///
+    /// # Example
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         Image("sample")
+    ///             .diffThreshold(0.2)
+    ///     }
+    /// }
+    /// ```
+    public func diffThreshold(_ diffThreshold: Float?) -> some View {
+        preference(key: PrecisionPreferenceKey.self, value: diffThreshold.map { 1 - $0 })
+    }
+}

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -26,7 +26,7 @@ struct SnapshotContext: Sendable, Encodable {
   let declaredDevice: String?
   let simulatorDeviceName: String?
   let simulatorModelIdentifier: String?
-  let precision: Float?
+  let diffThreshold: Float?
   let accessibilityEnabled: Bool?
   let colorScheme: String?
   let appStoreSnapshot: Bool?
@@ -60,6 +60,10 @@ private struct SnapshotCIExportSidecar: Sendable, Encodable {
 final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
 
   static let envKey = "SNAPSHOTS_EXPORT_DIR"
+
+  static func diffThreshold(for precision: Float?) -> Float? {
+    precision.map { 1 - $0 }
+  }
 
   private let exportDirectoryURL: URL
   private let writeQueue: OperationQueue

--- a/Sources/SnapshottingTests/SnapshotTest.swift
+++ b/Sources/SnapshottingTests/SnapshotTest.swift
@@ -206,7 +206,7 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
         declaredDevice: preview.device?.rawValue,
         simulatorDeviceName: ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"],
         simulatorModelIdentifier: ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"],
-        precision: result.precision,
+        diffThreshold: SnapshotCIExportCoordinator.diffThreshold(for: result.precision),
         accessibilityEnabled: result.accessibilityEnabled,
         colorScheme: colorSchemeValue,
         appStoreSnapshot: result.appStoreSnapshot)

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -248,6 +248,46 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     XCTAssertNil(json["context"])
   }
 
+  func testDiffThresholdIsDerivedFromPrecision() {
+    XCTAssertEqual(SnapshotCIExportCoordinator.diffThreshold(for: 1.0) ?? .zero, 0.0, accuracy: 0.000_1)
+    XCTAssertEqual(SnapshotCIExportCoordinator.diffThreshold(for: 0.8) ?? .zero, 0.2, accuracy: 0.000_1)
+    XCTAssertNil(SnapshotCIExportCoordinator.diffThreshold(for: nil))
+  }
+
+  func testSidecarIncludesDiffThreshold() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(
+      baseFileName: "TestView_DiffThreshold",
+      diffThreshold: 0.2
+    )
+
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+    let diffThreshold = try XCTUnwrap(json["diff_threshold"] as? Double)
+
+    XCTAssertEqual(diffThreshold, 0.2, accuracy: 0.000_1)
+  }
+
+  func testSidecarIncludesDiffThresholdWhenDerivedFromPrecision() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(
+      baseFileName: "TestView_BothThresholds",
+      diffThreshold: 0.2
+    )
+
+    coordinator.enqueueExport(
+      result: makeSuccessResult(precision: 0.95),
+      context: context)
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+    let diffThreshold = try XCTUnwrap(json["diff_threshold"] as? Double)
+
+    XCTAssertEqual(diffThreshold, 0.2, accuracy: 0.000_1)
+  }
+
   // MARK: - Render Failure
 
   func testRenderFailureProducesNoFiles() {
@@ -323,6 +363,7 @@ extension SnapshotCIExportCoordinatorTests {
     previewDisplayName: String? = "Preview",
     previewId: String = "0",
     previewIndex: Int = 0,
+    diffThreshold: Float? = nil,
     colorScheme: String? = nil
   ) -> SnapshotContext {
     SnapshotContext(
@@ -339,7 +380,7 @@ extension SnapshotCIExportCoordinatorTests {
       declaredDevice: nil,
       simulatorDeviceName: nil,
       simulatorModelIdentifier: nil,
-      precision: nil,
+      diffThreshold: diffThreshold,
       accessibilityEnabled: nil,
       colorScheme: colorScheme,
       appStoreSnapshot: nil
@@ -372,10 +413,10 @@ extension SnapshotCIExportCoordinatorTests {
     #endif
   }
 
-  private func makeSuccessResult() -> SnapshotResult {
+  private func makeSuccessResult(precision: Float? = nil) -> SnapshotResult {
     SnapshotResult(
       image: .success(makeTestImage()),
-      precision: nil,
+      precision: precision,
       accessibilityEnabled: nil,
       colorScheme: nil,
       appStoreSnapshot: nil


### PR DESCRIPTION
Add a `.diffThreshold(_:)` preview modifier for snapshot sidecars.

This introduces a new `diffThreshold` modifier for previews and exports the configured value as `diff_threshold` in snapshot sidecar JSON.

The existing `.emergeSnapshotPrecision(_:)` modifier remains available. Sidecar export derives `diff_threshold` from precision so existing precision-based previews continue to produce snapshot threshold metadata.

Demo examples now use `.diffThreshold(_:)`, and test coverage verifies both direct `diffThreshold` usage and `diff_threshold` derived from precision.

Refs EME-1053