### PR TITLE
ref(snapshotting): Restructure CI export sidecar schema

### DIFF
--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -36,7 +36,6 @@ private struct SnapshotSidecar: Sendable, Encodable {
   let group: String
   let tags: Tags?
   let diffThreshold: Float?
-  let colorMode: String?
   let context: Context
 
   struct Tags: Sendable, Encodable {
@@ -47,6 +46,7 @@ private struct SnapshotSidecar: Sendable, Encodable {
   struct Context: Sendable, Encodable {
     let testName: String
     let accessibilityEnabled: Bool
+    let preferredColorScheme: String?
     let simulator: Simulator?
     let preview: Preview
 
@@ -79,7 +79,6 @@ private struct SnapshotSidecar: Sendable, Encodable {
     self.displayName = displayName
     self.group = group
     self.diffThreshold = context.diffThreshold
-    self.colorMode = context.colorScheme
 
     let orientation = context.orientation.isEmpty ? nil : context.orientation
     let device = context.simulatorDeviceName.flatMap { $0.isEmpty ? nil : $0 }
@@ -98,6 +97,7 @@ private struct SnapshotSidecar: Sendable, Encodable {
     self.context = Context(
       testName: context.testName,
       accessibilityEnabled: context.accessibilityEnabled ?? false,
+      preferredColorScheme: context.colorScheme,
       simulator: simulator,
       preview: Context.Preview(
         index: context.previewIndex,

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -12,7 +12,7 @@ import XCTest
 
 // MARK: - Snapshot Context
 
-struct SnapshotContext: Sendable, Encodable {
+struct SnapshotContext: Sendable {
   let baseFileName: String
   let testName: String
   let typeName: String
@@ -21,37 +21,92 @@ struct SnapshotContext: Sendable, Encodable {
   let line: Int?
   let previewDisplayName: String?
   let previewIndex: Int
-  let previewId: String
   let orientation: String
-  let declaredDevice: String?
   let simulatorDeviceName: String?
   let simulatorModelIdentifier: String?
   let diffThreshold: Float?
   let accessibilityEnabled: Bool?
   let colorScheme: String?
-  let appStoreSnapshot: Bool?
 }
 
 // MARK: - Sidecar Model
 
-private struct SnapshotCIExportSidecar: Sendable, Encodable {
-  let context: SnapshotContext
-  let imageFileName: String
+private struct SnapshotSidecar: Sendable, Encodable {
   let displayName: String
   let group: String
+  let tags: Tags?
+  let diffThreshold: Float?
+  let colorMode: String?
+  let context: Context
 
-  private enum ExtraKeys: String, CodingKey {
-    case image_file_name
-    case display_name
-    case group
+  struct Tags: Sendable, Encodable {
+    let orientation: String?
+    let device: String?
   }
 
-  func encode(to encoder: Encoder) throws {
-    try context.encode(to: encoder)
-    var container = encoder.container(keyedBy: ExtraKeys.self)
-    try container.encode(imageFileName, forKey: .image_file_name)
-    try container.encode(displayName, forKey: .display_name)
-    try container.encode(group, forKey: .group)
+  struct Context: Sendable, Encodable {
+    let testName: String
+    let accessibilityEnabled: Bool
+    let simulator: Simulator?
+    let preview: Preview
+
+    struct Simulator: Sendable, Encodable {
+      let deviceName: String?
+      let modelIdentifier: String?
+    }
+    
+    struct Preview: Sendable, Encodable {
+      let index: Int
+      /// The author-declared `.previewDisplayName(...)` value, if set.
+      let displayName: String?
+      /// Fully-qualified type name of the container that declared this preview
+      /// (the `PreviewProvider` struct, or the compiler-synthesized `PreviewRegistry`
+      /// conformance for a `#Preview` macro).
+      let containerTypeName: String
+      /// Human-readable label derived from the container's type name or file name.
+      /// Not author-declared — there's no SwiftUI API to set it.
+      let containerDisplayName: String
+      let line: Int?
+    }
+  }
+
+  init(
+    context: SnapshotContext,
+    imageFileName: String,
+    displayName: String,
+    group: String
+  ) {
+    self.displayName = displayName
+    self.group = group
+    self.diffThreshold = context.diffThreshold
+    self.colorMode = context.colorScheme
+
+    let orientation = context.orientation.isEmpty ? nil : context.orientation
+    let device = context.simulatorDeviceName.flatMap { $0.isEmpty ? nil : $0 }
+    self.tags = (orientation == nil && device == nil)
+      ? nil
+      : Tags(orientation: orientation, device: device)
+
+    let simulator: Context.Simulator? =
+      (context.simulatorDeviceName == nil && context.simulatorModelIdentifier == nil)
+      ? nil
+      : Context.Simulator(
+          deviceName: context.simulatorDeviceName,
+          modelIdentifier: context.simulatorModelIdentifier
+        )
+
+    self.context = Context(
+      testName: context.testName,
+      accessibilityEnabled: context.accessibilityEnabled ?? false,
+      simulator: simulator,
+      preview: Context.Preview(
+        index: context.previewIndex,
+        displayName: context.previewDisplayName,
+        containerTypeName: context.typeName,
+        containerDisplayName: context.typeDisplayName,
+        line: context.line
+      )
+    )
   }
 }
 
@@ -222,7 +277,7 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
         return
       }
 
-      let sidecar = SnapshotCIExportSidecar(
+      let sidecar = SnapshotSidecar(
         context: context,
         imageFileName: context.baseFileName,
         displayName: displayName,

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -34,19 +34,12 @@ struct SnapshotContext: Sendable {
 private struct SnapshotSidecar: Sendable, Encodable {
   let displayName: String
   let group: String
-  let tags: Tags?
   let diffThreshold: Float?
   let context: Context
-
-  struct Tags: Sendable, Encodable {
-    let orientation: String?
-    let device: String?
-  }
 
   struct Context: Sendable, Encodable {
     let testName: String
     let accessibilityEnabled: Bool
-    let preferredColorScheme: String?
     let simulator: Simulator?
     let preview: Preview
 
@@ -66,6 +59,11 @@ private struct SnapshotSidecar: Sendable, Encodable {
       /// Human-readable label derived from the container's type name or file name.
       /// Not author-declared — there's no SwiftUI API to set it.
       let containerDisplayName: String
+      /// The author-declared `.preferredColorScheme(_:)` value, if set. `"light"` or `"dark"`.
+      let preferredColorScheme: String?
+      /// The author-declared preview interface orientation (e.g. `"portrait"`, `"landscapeLeft"`).
+      /// Defaults to `"portrait"` when the author doesn't declare one.
+      let orientation: String?
       let line: Int?
     }
   }
@@ -80,12 +78,6 @@ private struct SnapshotSidecar: Sendable, Encodable {
     self.group = group
     self.diffThreshold = context.diffThreshold
 
-    let orientation = context.orientation.isEmpty ? nil : context.orientation
-    let device = context.simulatorDeviceName.flatMap { $0.isEmpty ? nil : $0 }
-    self.tags = (orientation == nil && device == nil)
-      ? nil
-      : Tags(orientation: orientation, device: device)
-
     let simulator: Context.Simulator? =
       (context.simulatorDeviceName == nil && context.simulatorModelIdentifier == nil)
       ? nil
@@ -97,13 +89,14 @@ private struct SnapshotSidecar: Sendable, Encodable {
     self.context = Context(
       testName: context.testName,
       accessibilityEnabled: context.accessibilityEnabled ?? false,
-      preferredColorScheme: context.colorScheme,
       simulator: simulator,
       preview: Context.Preview(
         index: context.previewIndex,
         displayName: context.previewDisplayName,
         containerTypeName: context.typeName,
         containerDisplayName: context.typeDisplayName,
+        preferredColorScheme: context.colorScheme,
+        orientation: context.orientation.isEmpty ? nil : context.orientation,
         line: context.line
       )
     )

--- a/Sources/SnapshottingTests/SnapshotTest.swift
+++ b/Sources/SnapshottingTests/SnapshotTest.swift
@@ -11,14 +11,14 @@ import enum SwiftUI.ColorScheme
 import XCTest
 
 extension ColorScheme {
-  var stringValue: String {
+  var stringValue: String? {
     switch self {
     case .light:
       return "light"
     case .dark:
       return "dark"
     @unknown default:
-      return "unknown"
+      return nil
     }
   }
 }
@@ -271,7 +271,7 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
 
     let baseFileName = SnapshotCIExportCoordinator.sanitize(rawBaseFileName)
     if let coordinator = Self.ciExportCoordinator {
-      let colorSchemeValue = result.colorScheme?.stringValue
+      let colorSchemeValue = result.colorScheme.flatMap { $0.stringValue }
       let context = SnapshotContext(
         baseFileName: baseFileName,
         testName: name,
@@ -281,15 +281,12 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
         line: previewType.line,
         previewDisplayName: preview.displayName,
         previewIndex: discoveredPreview.index,
-        previewId: preview.previewId,
         orientation: preview.orientation.id,
-        declaredDevice: preview.device?.rawValue,
         simulatorDeviceName: ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"],
         simulatorModelIdentifier: ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"],
         diffThreshold: SnapshotCIExportCoordinator.diffThreshold(for: result.precision),
         accessibilityEnabled: result.accessibilityEnabled,
-        colorScheme: colorSchemeValue,
-        appStoreSnapshot: result.appStoreSnapshot)
+        colorScheme: colorSchemeValue)
       coordinator.enqueueExport(result: result, context: context)
     } else {
       do {

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -305,12 +305,13 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     XCTAssertEqual(preview["index"] as? Int, 0)
     XCTAssertEqual(preview["line"] as? Int, 99)
     XCTAssertEqual(tags["orientation"] as? String, "portrait")
-    XCTAssertEqual(json["color_mode"] as? String, "dark")
+    XCTAssertEqual(nestedContext["preferred_color_scheme"] as? String, "dark")
     XCTAssertEqual(nestedContext["test_name"] as? String, context.testName)
 
     // Fields that previously sat at the top level no longer do.
     XCTAssertNil(json["type_name"])
     XCTAssertNil(json["line"])
+    XCTAssertNil(json["color_mode"])
     XCTAssertNil(json["color_scheme"])
     XCTAssertNil(json["orientation"])
   }

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -296,7 +296,6 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
 
     let json = try readJSON(forBaseFileName: context.baseFileName)
     let nestedContext = try XCTUnwrap(json["context"] as? [String: Any])
-    let tags = try XCTUnwrap(json["tags"] as? [String: Any])
     let preview = try XCTUnwrap(nestedContext["preview"] as? [String: Any])
 
     XCTAssertEqual(preview["container_type_name"] as? String, context.typeName)
@@ -304,11 +303,12 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     XCTAssertEqual(preview["display_name"] as? String, context.previewDisplayName)
     XCTAssertEqual(preview["index"] as? Int, 0)
     XCTAssertEqual(preview["line"] as? Int, 99)
-    XCTAssertEqual(tags["orientation"] as? String, "portrait")
-    XCTAssertEqual(nestedContext["preferred_color_scheme"] as? String, "dark")
+    XCTAssertEqual(preview["orientation"] as? String, "portrait")
+    XCTAssertEqual(preview["preferred_color_scheme"] as? String, "dark")
     XCTAssertEqual(nestedContext["test_name"] as? String, context.testName)
 
     // Fields that previously sat at the top level no longer do.
+    XCTAssertNil(json["tags"])
     XCTAssertNil(json["type_name"])
     XCTAssertNil(json["line"])
     XCTAssertNil(json["color_mode"])

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -206,7 +206,6 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
 
     let json = try readJSON(forBaseFileName: context.baseFileName)
 
-    XCTAssertEqual(json["image_file_name"] as? String, context.baseFileName)
     XCTAssertEqual(json["display_name"] as? String, "Dark Mode")
     XCTAssertEqual(json["group"] as? String, "Login Screen")
   }
@@ -254,7 +253,6 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
       fileId: nil,
       line: nil,
       previewDisplayName: nil,
-      previewId: "0",
       previewIndex: 0
     )
 
@@ -285,12 +283,11 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     XCTAssertEqual(json["group"] as? String, "MyModule.TestView_Previews")
   }
 
-  func testSidecarFlattensContextFields() throws {
+  func testSidecarNestsContextFieldsUnderContextKey() throws {
     let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
     let context = makeContext(
       baseFileName: "TestView_Preview",
       line: 99,
-      previewId: "7",
       colorScheme: "dark"
     )
 
@@ -298,13 +295,24 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     coordinator.drain()
 
     let json = try readJSON(forBaseFileName: context.baseFileName)
+    let nestedContext = try XCTUnwrap(json["context"] as? [String: Any])
+    let tags = try XCTUnwrap(json["tags"] as? [String: Any])
+    let preview = try XCTUnwrap(nestedContext["preview"] as? [String: Any])
 
-    XCTAssertEqual(json["type_name"] as? String, context.typeName)
-    XCTAssertEqual(json["orientation"] as? String, "portrait")
-    XCTAssertEqual(json["preview_id"] as? String, "7")
-    XCTAssertEqual(json["line"] as? Int, 99)
-    XCTAssertEqual(json["color_scheme"] as? String, "dark")
-    XCTAssertNil(json["context"])
+    XCTAssertEqual(preview["container_type_name"] as? String, context.typeName)
+    XCTAssertEqual(preview["container_display_name"] as? String, context.typeDisplayName)
+    XCTAssertEqual(preview["display_name"] as? String, context.previewDisplayName)
+    XCTAssertEqual(preview["index"] as? Int, 0)
+    XCTAssertEqual(preview["line"] as? Int, 99)
+    XCTAssertEqual(tags["orientation"] as? String, "portrait")
+    XCTAssertEqual(json["color_mode"] as? String, "dark")
+    XCTAssertEqual(nestedContext["test_name"] as? String, context.testName)
+
+    // Fields that previously sat at the top level no longer do.
+    XCTAssertNil(json["type_name"])
+    XCTAssertNil(json["line"])
+    XCTAssertNil(json["color_scheme"])
+    XCTAssertNil(json["orientation"])
   }
 
   func testDiffThresholdIsDerivedFromPrecision() {
@@ -387,7 +395,6 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
       makeContext(
         baseFileName: "View\(i)_Preview",
         typeName: "Module.View\(i)",
-        previewId: "\(i)",
         previewIndex: i
       )
     }
@@ -440,7 +447,6 @@ extension SnapshotCIExportCoordinatorTests {
     fileId: String? = nil,
     line: Int? = nil,
     previewDisplayName: String? = "Preview",
-    previewId: String = "0",
     previewIndex: Int = 0,
     diffThreshold: Float? = nil,
     colorScheme: String? = nil
@@ -454,15 +460,12 @@ extension SnapshotCIExportCoordinatorTests {
       line: line,
       previewDisplayName: previewDisplayName,
       previewIndex: previewIndex,
-      previewId: previewId,
       orientation: "portrait",
-      declaredDevice: nil,
       simulatorDeviceName: nil,
       simulatorModelIdentifier: nil,
       diffThreshold: diffThreshold,
       accessibilityEnabled: nil,
-      colorScheme: colorScheme,
-      appStoreSnapshot: nil
+      colorScheme: colorScheme
     )
   }
 


### PR DESCRIPTION
Restructures the JSON sidecar emitted via `SNAPSHOTS_EXPORT_DIR` from a flat blob into a nested schema with explicit top-level fields (`display_name`, `group`, `diff_threshold`) and a nested `context` object that groups runtime/environment data and per-preview author declarations.

### Schema

```jsonc
{
  "display_name":    "...",   // canonical label for UI (author's .previewDisplayName, or derived fallback)
  "group":           "...",   // file path (#Preview) or container type display name (PreviewProvider)
  "diff_threshold":  0.0,     // optional, derived from preview precision
  "context": {
    "test_name":               "...",
    "accessibility_enabled":   false,
    "simulator": {             // optional — drops when no sim env vars
      "device_name":       "iPhone 17 Pro Max",
      "model_identifier":  "iPhone18,2"
    },
    "preview": {
      "index":                  0,
      "display_name":           "...",     // optional — raw .previewDisplayName(...) value, absent if author didn't set one
      "container_type_name":    "...",     // PreviewProvider type OR mangled PreviewRegistry conformance name
      "container_display_name": "...",     // derived pretty label from type/file name
      "preferred_color_scheme": "light",   // optional — from author's .preferredColorScheme(_:); enum: "light" | "dark"
      "orientation":            "portrait",// from author's .previewInterfaceOrientation(_:) or #Preview trait (default "portrait")
      "line":                   60         // optional — present only for #Preview macro
    }
  }
}
```

### Key design decisions

- **Top-level fields surface anything a dashboard filters/groups by.** Raw metadata stays under `context`.
- **`context.preview` groups everything the author declared about this specific preview.** `display_name`, `preferred_color_scheme`, `orientation`, and `line` all flow from per-preview modifiers or the `#Preview` macro invocation site. Sits next to container identity (`container_type_name`, `container_display_name`) so each preview record is self-contained.
- **`context.simulator` is the runtime environment** — sourced purely from `SIMULATOR_DEVICE_NAME` / `SIMULATOR_MODEL_IDENTIFIER` env vars. Orientation is explicitly not here — despite the simulator being rotated to match during capture, the canonical value is the author's declaration.
- **`preferred_color_scheme` mirrors SwiftUI's `.preferredColorScheme(_:)` modifier.** Mapped at the source (`SwiftUI.ColorScheme.stringValue` now returns `String?`) so `@unknown default` drops out instead of emitting `"unknown"`.
- **`container_type_name`** is the type that *declared* the preview, not the view being previewed. For `PreviewProvider` this is your struct (`HackerNews.CommentView_Preview`); for `#Preview` it's a compiler-synthesized `PreviewRegistry` conformance (mangled name). A "view-under-test" field would require either fragile SwiftUI reflection or a new preference-key modifier — out of scope here.
- **`container_display_name`** is a derived pretty label, not author-declared. Doc-commented at the source so future readers don't re-ask.
- **Dead fields removed from `SnapshotContext`**: `previewId` (redundant — always `"\(index)"`), `appStoreSnapshot` (not emitted anywhere after the refactor), `declaredDevice` (filtered upstream — `PreviewBaseTest` already skips previews whose declared device doesn't match the host sim).

---

### Sample sidecars

Four examples covering the full matrix: `PreviewProvider` vs `#Preview` macro × named vs anonymous × with/without `preferred_color_scheme`. Samples reflect the current schema; the on-disk fixtures under `/private/tmp/snapshots25/iphone` will regenerate to this shape on next export.

#### 1. `PreviewProvider` with `.previewDisplayName` + `.preferredColorScheme(.dark)`

Shows `preferred_color_scheme` + `orientation` nested under `preview`, author-set `display_name`, readable `container_type_name` (no mangling), `index` disambiguating multiple previews in the same provider.

```swift
struct CommentView_Preview: PreviewProvider {
  static var previews: some View {
    Group {
      CommentView(...)
        .previewDisplayName("Light mode")           // index 0
      CommentView(...)
        .preferredColorScheme(.dark)
        .previewDisplayName("Dark mode")            // ← index 1 (this snapshot)
    }
  }
}
```

```json
{
  "context" : {
    "accessibility_enabled" : false,
    "preview" : {
      "container_display_name" : "Comment View Preview",
      "container_type_name" : "HackerNews.CommentView_Preview",
      "display_name" : "Dark mode",
      "index" : 1,
      "orientation" : "portrait",
      "preferred_color_scheme" : "dark"
    },
    "simulator" : {
      "device_name" : "iPhone 17 Pro Max",
      "model_identifier" : "iPhone18,2"
    },
    "test_name" : "-[HackerNewsSnapshotTest portrait-Comment View Preview-1-6]"
  },
  "display_name" : "Dark mode",
  "group" : "Comment View Preview"
}
```

#### 2. `PreviewProvider` + `ForEach` (multiple indexed previews, all named)

One container, six previews. Each gets a distinct `index` and a per-iteration `.previewDisplayName("Indentation \(i)")`. The `container_type_name` is shared; the individual `display_name` + `index` identify the specific snapshot.

```swift
struct CommentViewIndentation_Preview: PreviewProvider {
  static var previews: some View {
    ForEach(0..<6) { i in
      CommentRow(indentation: i)
        .previewDisplayName("Indentation \(i)")    // ← "Indentation 0" when i == 0
    }
  }
}
```

```json
{
  "context" : {
    "accessibility_enabled" : false,
    "preview" : {
      "container_display_name" : "Comment View Indentation Preview",
      "container_type_name" : "HackerNews.CommentViewIndentation_Preview",
      "display_name" : "Indentation 0",
      "index" : 0,
      "orientation" : "portrait"
    },
    "simulator" : {
      "device_name" : "iPhone 17 Pro Max",
      "model_identifier" : "iPhone18,2"
    },
    "test_name" : "-[HackerNewsSnapshotTest portrait-Comment View Indentation Preview-0-8]"
  },
  "display_name" : "Indentation 0",
  "group" : "Comment View Indentation Preview"
}
```

#### 3. `#Preview` macro, anonymous

No `.previewDisplayName` — `preview.display_name` is absent. Top-level `display_name` falls back to `"At line #60"`. `container_type_name` is the mangled `PreviewRegistry` conformance. `container_display_name` is derived from the filename (`BookmarksScreen.swift` → `"Bookmarks Screen"`). `group` is the file path.

```swift
// BookmarksScreen.swift
#Preview {                                        // ← line 60
  BookmarksScreen()
}
```

```json
{
  "context" : {
    "accessibility_enabled" : false,
    "preview" : {
      "container_display_name" : "Bookmarks Screen",
      "container_type_name" : "HackerNews.$s10HackerNews0026BookmarksScreenswift_DsAGgfMX59_0_33_02471A937C398E062128603F3D06A485Ll7PreviewfMf_15PreviewRegistryfMu_",
      "index" : 0,
      "line" : 60,
      "orientation" : "portrait"
    },
    "simulator" : {
      "device_name" : "iPhone 17 Pro Max",
      "model_identifier" : "iPhone18,2"
    },
    "test_name" : "-[HackerNewsSnapshotTest portrait-Bookmarks Screen-0-3]"
  },
  "display_name" : "At line #60",
  "group" : "HackerNews/BookmarksScreen.swift"
}
```

#### 4. `#Preview` macro with `.previewDisplayName`

All macro-preview fields populated: `preview.display_name` set, `line` present, mangled `container_type_name`, `container_display_name` derived from filename.

```swift
// CommentRow.swift
#Preview("HTML case 1") {                         // ← line 152
  CommentRow(text: "<b>bold</b>")
}
```

```json
{
  "context" : {
    "accessibility_enabled" : false,
    "preview" : {
      "container_display_name" : "Comment Row",
      "container_type_name" : "HackerNews.$s10HackerNews0021CommentRowswift_IfFDefMX151_0_33_B693E36E869B3E541838B120FF6BB995Ll7PreviewfMf_15PreviewRegistryfMu_",
      "display_name" : "HTML case 1",
      "index" : 0,
      "line" : 152,
      "orientation" : "portrait"
    },
    "simulator" : {
      "device_name" : "iPhone 17 Pro Max",
      "model_identifier" : "iPhone18,2"
    },
    "test_name" : "-[HackerNewsSnapshotTest portrait-Comment Row-0-14]"
  },
  "display_name" : "HTML case 1",
  "group" : "HackerNews/CommentRow.swift"
}
```

---

Closes EME-1073