### PR TITLE
feat(snapshot): Add metadata modifiers

### DIFF
--- a/Examples/DemoApp/DemoApp/TestViews/RideShareButton.swift
+++ b/Examples/DemoApp/DemoApp/TestViews/RideShareButton.swift
@@ -35,7 +35,7 @@ struct RideShareButtonView_Previews: PreviewProvider {
         .padding()
         .previewDisplayName("Ride Share Button View - Light")
         // This should never show as a diff
-        .diffThreshold(1.0)
+        .snapshotDiffThreshold(1.0)
       #if os(iOS)
         .snapshotRenderingMode(.coreAnimation)
       #endif

--- a/Examples/DemoApp/DemoModule/HomeMapView.swift
+++ b/Examples/DemoApp/DemoModule/HomeMapView.swift
@@ -46,6 +46,6 @@ struct HomeMapView: View {
 struct HomeMapView_Previews: PreviewProvider {
     static var previews: some View {
         HomeMapView(address: "123 Main St, San Francisco, CA")
-        .diffThreshold(0.1)
+        .snapshotDiffThreshold(0.1)
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         // Target that provides the XCTest
       .target(name: "SnapshottingTestsObjc", dependencies: [.product(name: "SimpleDebugger", package: "SimpleDebugger", condition: .when(platforms: [.iOS, .macOS, .macCatalyst]))]),
-        .target(name: "SnapshottingTests", dependencies: ["SnapshotPreviewsCore", "SnapshottingTestsObjc"]),
+        .target(name: "SnapshottingTests", dependencies: ["SnapshotPreviewsCore", "SnapshottingTestsObjc", "SnapshotSharedModels"]),
         .target(name: "SnapshotSharedModels"),
         // Core functionality
         .target(name: "SnapshotPreviewsCore", dependencies: ["PreviewsSupport", "SnapshotSharedModels"]),
@@ -60,8 +60,11 @@ let package = Package(
             name: "SnapshotPreviewsTests",
             dependencies: ["SnapshotPreviewsCore"]),
         .testTarget(
+            name: "SnapshotPreferencesTests",
+            dependencies: ["SnapshotPreferences", "SnapshotSharedModels"]),
+        .testTarget(
             name: "SnapshottingTestsTests",
-            dependencies: ["SnapshottingTests", "SnapshotPreviewsCore"]),
+            dependencies: ["SnapshottingTests", "SnapshotPreviewsCore", "SnapshotSharedModels"]),
     ],
     cxxLanguageStandard: .cxx11
 )

--- a/README.md
+++ b/README.md
@@ -92,16 +92,23 @@ The sidecar includes:
 | `display_name` | Snapshot name shown in Sentry. Generated from the preview name, file path, and module so exported filenames stay stable and unambiguous. |
 | `group` | Grouping key Sentry uses to organize related snapshots. Generated from the preview name, file path, and module. |
 | `diff_threshold` | Allowed visual difference for this snapshot. See details below. |
-| `context` | Supporting metadata such as test name, simulator info, orientation, color scheme, source line, and preview attributes. These fields are surfaced on the snapshot detail page in Sentry's UI. |
+| `tags` | Optional key-value pairs used to filter and group snapshots in Sentry. |
+| `context` | Supporting metadata such as test name, simulator info, orientation, color scheme, source line, preview attributes, and any custom context you add. These fields are surfaced on the snapshot detail page in Sentry's UI. |
 
-Use the `.diffThreshold(...)` view modifier from the `SnapshotPreferences` product to customize the allowed visual difference for a specific preview. For example, `.diffThreshold(0.05)` allows up to a 5% difference for that snapshot.
+SnapshotPreviews adds these `context` keys by default when values are available: `test_name`, `accessibility_enabled`, `simulator.device_name`, `simulator.model_identifier`, `preview.index`, `preview.display_name`, `preview.container_type_name`, `preview.container_display_name`, `preview.preferred_color_scheme`, `preview.orientation`, and `preview.line`.
+
+Use `.snapshotAdditionalContext(...)` to add custom fields to `context`. Custom context is shallow-merged into the generated context, so a custom key such as `"test_name"` replaces the generated value. Supported custom values are strings, numbers, booleans, and nested objects.
+
+Use the `.snapshotDiffThreshold(...)` view modifier from the `SnapshotPreferences` product to customize the allowed visual difference for a specific preview. For example, `.snapshotDiffThreshold(0.05)` allows up to a 5% difference for that snapshot.
 
 ```swift
 import SnapshotPreferences
 
 #Preview("Map") {
   MapPreview()
-    .diffThreshold(0.05)
+    .snapshotTags(["screen": "map"])
+    .snapshotAdditionalContext(["fixture": "city-route"])
+    .snapshotDiffThreshold(0.05)
 }
 ```
 
@@ -194,6 +201,9 @@ Link the `SnapshotPreferences` product to your app target to customize individua
 | `.snapshotAccessibility(true)` | You want an accessibility-focused variant. | On iOS, renders the snapshot through the accessibility overlay wrapper configured by your `SnapshotTest`, showing accessibility elements and labels instead of the plain view. The exported sidecar also records that accessibility was enabled. |
 | `.snapshotRenderingMode(.coreAnimation)` | The default renderer misses, flakes on, or incorrectly draws a view. | Changes the pixel capture backend. For example, `.coreAnimation` uses the layer tree, `.uiView` uses UIKit hierarchy drawing, and `.window` captures the full window. Different modes can affect blur/materials, maps, animations, and other renderer-sensitive content. |
 | `.snapshotExpansion(false)` | You want to preserve the visible scroll viewport instead of capturing all scroll content. | By default, scroll views are expanded so the snapshot includes their full content. Setting this to `false` keeps the scroll view at its normal visible height. |
+| `.snapshotTags(["area": "checkout"])` | You want searchable labels on the exported snapshot. | Adds top-level `tags` to the JSON sidecar. Repeated tag modifiers merge, and later duplicate keys win. |
+| `.snapshotAdditionalContext(["fixture": "loaded"])` | You want extra sidecar metadata for debugging or filtering. | Adds fields to the JSON sidecar `context` object. Repeated context modifiers merge, and later duplicate keys win. Custom keys override generated context keys. |
+| `.snapshotDiffThreshold(0.05)` | A snapshot has small expected pixel differences. | Sets `diff_threshold` in the exported sidecar for this preview. `0.05` allows up to a 5% changed-pixel share before Sentry marks the image as changed. |
 
 ## Variants
 

--- a/Sources/SnapshotPreferences/DiffThresholdPreference.swift
+++ b/Sources/SnapshotPreferences/DiffThresholdPreference.swift
@@ -25,11 +25,16 @@ extension View {
     /// struct ContentView: View {
     ///     var body: some View {
     ///         Image("sample")
-    ///             .diffThreshold(0.2)
+    ///             .snapshotDiffThreshold(0.2)
     ///     }
     /// }
     /// ```
-    public func diffThreshold(_ diffThreshold: Float?) -> some View {
+    public func snapshotDiffThreshold(_ diffThreshold: Float?) -> some View {
         preference(key: PrecisionPreferenceKey.self, value: diffThreshold.map { 1 - $0 })
+    }
+
+    @available(*, deprecated, renamed: "snapshotDiffThreshold(_:)")
+    public func diffThreshold(_ diffThreshold: Float?) -> some View {
+        snapshotDiffThreshold(diffThreshold)
     }
 }

--- a/Sources/SnapshotPreferences/EmergeModifierFinder.swift
+++ b/Sources/SnapshotPreferences/EmergeModifierFinder.swift
@@ -24,6 +24,9 @@ class EmergeModifierState: NSObject {
     renderingMode = nil
     precision = nil
     accessibilityEnabled = nil
+    appStoreSnapshot = nil
+    tags = [:]
+    additionalContext = [:]
   }
 
   var expansionPreference: Bool?
@@ -31,6 +34,8 @@ class EmergeModifierState: NSObject {
   var precision: Float?
   var accessibilityEnabled: Bool?
   var appStoreSnapshot: Bool?
+  var tags: [String: String] = [:]
+  var additionalContext: [String: SnapshotMetadataValue] = [:]
 }
 
 @objc(EmergeModifierFinder)
@@ -52,6 +57,12 @@ class EmergeModifierFinder: NSObject {
       })
       .onPreferenceChange(AppStoreSnapshotPreferenceKey.self, perform: { value in
         EmergeModifierState.shared.appStoreSnapshot = value
+      })
+      .onPreferenceChange(SnapshotTagsPreferenceKey.self, perform: { value in
+        EmergeModifierState.shared.tags = value
+      })
+      .onPreferenceChange(SnapshotAdditionalContextPreferenceKey.self, perform: { value in
+        EmergeModifierState.shared.additionalContext = value
       })
   }
 }

--- a/Sources/SnapshotPreferences/SnapshotMetadataPreference.swift
+++ b/Sources/SnapshotPreferences/SnapshotMetadataPreference.swift
@@ -1,0 +1,48 @@
+//
+//  SnapshotMetadataPreference.swift
+//
+
+import Foundation
+import SwiftUI
+import SnapshotSharedModels
+
+struct SnapshotTagsPreferenceKey: PreferenceKey {
+  static var defaultValue: [String: String] = [:]
+
+  static func reduce(value: inout [String: String], nextValue: () -> [String: String]) {
+    value.merge(nextValue(), uniquingKeysWith: { _, new in new })
+  }
+}
+
+struct SnapshotAdditionalContextPreferenceKey: PreferenceKey {
+  static var defaultValue: [String: SnapshotMetadataValue] = [:]
+
+  static func reduce(
+    value: inout [String: SnapshotMetadataValue],
+    nextValue: () -> [String: SnapshotMetadataValue]
+  ) {
+    value.merge(nextValue(), uniquingKeysWith: { _, new in new })
+  }
+}
+
+extension View {
+  /// Adds tags to the exported snapshot sidecar.
+  ///
+  /// Repeated modifiers merge their dictionaries. If the same key is set more than once,
+  /// the later modifier value is used.
+  public func snapshotTags(_ tags: [String: String]) -> some View {
+    preference(key: SnapshotTagsPreferenceKey.self, value: tags)
+  }
+
+  /// Adds custom metadata to the exported snapshot sidecar `context` object.
+  ///
+  /// Supported values are strings, numbers, booleans, and nested dictionaries containing
+  /// those same value types. Repeated modifiers merge their dictionaries. If the same key
+  /// is set more than once, the later modifier value is used.
+  public func snapshotAdditionalContext(_ context: [String: Any]) -> some View {
+    preference(
+      key: SnapshotAdditionalContextPreferenceKey.self,
+      value: SnapshotMetadataValue.dictionary(from: context)
+    )
+  }
+}

--- a/Sources/SnapshotPreviewsCore/AppKitRenderingStrategy.swift
+++ b/Sources/SnapshotPreviewsCore/AppKitRenderingStrategy.swift
@@ -47,7 +47,7 @@ public class AppKitRenderingStrategy: RenderingStrategy {
     window.contentViewController = NSViewController()
     window.setContentSize(AppKitContainer.defaultSize)
     window.contentViewController = vc
-    vc.rendered = { [weak window, weak vc] mode, precision, accessibilityEnabled, appStoreSnapshot in
+    vc.rendered = { [weak window, weak vc] mode, precision, accessibilityEnabled, appStoreSnapshot, tags, additionalContext in
       DispatchQueue.main.async {
         Self.takeSnapshot(mode: mode ?? .nsView, viewController: vc, window: window) { image in
           completion(
@@ -56,7 +56,9 @@ public class AppKitRenderingStrategy: RenderingStrategy {
               precision: precision,
               accessibilityEnabled: accessibilityEnabled,
               colorScheme: _colorScheme,
-              appStoreSnapshot: appStoreSnapshot))
+              appStoreSnapshot: appStoreSnapshot,
+              tags: tags,
+              additionalContext: additionalContext))
         }
       }
     }
@@ -116,7 +118,7 @@ final class AppKitContainer: NSHostingController<EmergeModifierView>, ScrollExpa
   var heightAnchor: NSLayoutConstraint?
   var previousHeight: CGFloat?
 
-  public var rendered: ((EmergeRenderingMode?, Float?, Bool?, Bool?) -> Void)? {
+  public var rendered: ((EmergeRenderingMode?, Float?, Bool?, Bool?, [String: String], [String: SnapshotMetadataValue]) -> Void)? {
     didSet { didCall = false }
   }
 
@@ -166,7 +168,7 @@ final class AppKitContainer: NSHostingController<EmergeModifierView>, ScrollExpa
     guard !didCall else { return }
 
     didCall = true
-    rendered?(rootView.emergeRenderingMode, rootView.precision, rootView.accessibilityEnabled, rootView.appStoreSnapshot)
+    rendered?(rootView.emergeRenderingMode, rootView.precision, rootView.accessibilityEnabled, rootView.appStoreSnapshot, rootView.tags, rootView.additionalContext)
   }
 
   override func updateViewConstraints() {

--- a/Sources/SnapshotPreviewsCore/ExpandingViewController.swift
+++ b/Sources/SnapshotPreviewsCore/ExpandingViewController.swift
@@ -31,7 +31,7 @@ public final class ExpandingViewController: UIHostingController<EmergeModifierVi
   private var startTime: UInt64?
   private var timer: Timer?
 
-  public var expansionSettled: ((EmergeRenderingMode?, Float?, Bool?, Bool?, Error?) -> Void)? {
+  public var expansionSettled: ((EmergeRenderingMode?, Float?, Bool?, Bool?, [String: String], [String: SnapshotMetadataValue], Error?) -> Void)? {
     didSet { didCall = false }
   }
 
@@ -78,7 +78,7 @@ public final class ExpandingViewController: UIHostingController<EmergeModifierVi
     guard !didCall else { return }
 
     didCall = true
-    expansionSettled?(rootView.emergeRenderingMode, rootView.precision, rootView.accessibilityEnabled, rootView.appStoreSnapshot, error)
+    expansionSettled?(rootView.emergeRenderingMode, rootView.precision, rootView.accessibilityEnabled, rootView.appStoreSnapshot, rootView.tags, rootView.additionalContext, error)
     stopAndResetTimer()
   }
 

--- a/Sources/SnapshotPreviewsCore/ModifierFinder.swift
+++ b/Sources/SnapshotPreviewsCore/ModifierFinder.swift
@@ -47,6 +47,14 @@ public struct EmergeModifierView: View {
     stateMirror?.descendant("precision") as? Float
   }
 
+  var tags: [String: String] {
+    stateMirror?.descendant("tags") as? [String: String] ?? [:]
+  }
+
+  var additionalContext: [String: SnapshotMetadataValue] {
+    stateMirror?.descendant("additionalContext") as? [String: SnapshotMetadataValue] ?? [:]
+  }
+
   var supportsExpansion: Bool {
     stateMirror?.descendant("expansionPreference") as? Bool ?? true
   }

--- a/Sources/SnapshotPreviewsCore/RenderingStrategy.swift
+++ b/Sources/SnapshotPreviewsCore/RenderingStrategy.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import SnapshotSharedModels
 
 #if canImport(UIKit)
 import UIKit
@@ -29,13 +30,17 @@ public struct SnapshotResult {
     precision: Float?,
     accessibilityEnabled: Bool?,
     colorScheme: ColorScheme?,
-    appStoreSnapshot: Bool?)
+    appStoreSnapshot: Bool?,
+    tags: [String: String] = [:],
+    additionalContext: [String: SnapshotMetadataValue] = [:])
   {
     self.image = image
     self.precision = precision
     self.accessibilityEnabled = accessibilityEnabled
     self.colorScheme = colorScheme
     self.appStoreSnapshot = appStoreSnapshot
+    self.tags = tags
+    self.additionalContext = additionalContext
   }
 
   public let image: Result<ImageType, Error>
@@ -43,6 +48,8 @@ public struct SnapshotResult {
   public let accessibilityEnabled: Bool?
   public let colorScheme: ColorScheme?
   public let appStoreSnapshot: Bool?
+  public let tags: [String: String]
+  public let additionalContext: [String: SnapshotMetadataValue]
 }
 
 public protocol RenderingStrategy {

--- a/Sources/SnapshotPreviewsCore/SwiftUIRenderingStrategy.swift
+++ b/Sources/SnapshotPreviewsCore/SwiftUIRenderingStrategy.swift
@@ -35,9 +35,9 @@ public class SwiftUIRenderingStrategy: RenderingStrategy {
     let image = renderer.nsImage
     #endif
     if let image {
-      completion(SnapshotResult(image: .success(image), precision: wrappedView.precision, accessibilityEnabled: wrappedView.accessibilityEnabled, colorScheme: colorScheme, appStoreSnapshot: wrappedView.appStoreSnapshot))
+      completion(SnapshotResult(image: .success(image), precision: wrappedView.precision, accessibilityEnabled: wrappedView.accessibilityEnabled, colorScheme: colorScheme, appStoreSnapshot: wrappedView.appStoreSnapshot, tags: wrappedView.tags, additionalContext: wrappedView.additionalContext))
     } else {
-      completion(SnapshotResult(image: .failure(RenderingError.failedRendering(.zero)), precision: wrappedView.precision, accessibilityEnabled: wrappedView.accessibilityEnabled, colorScheme: colorScheme, appStoreSnapshot: wrappedView.appStoreSnapshot))
+      completion(SnapshotResult(image: .failure(RenderingError.failedRendering(.zero)), precision: wrappedView.precision, accessibilityEnabled: wrappedView.accessibilityEnabled, colorScheme: colorScheme, appStoreSnapshot: wrappedView.appStoreSnapshot, tags: wrappedView.tags, additionalContext: wrappedView.additionalContext))
     }
   }
 }

--- a/Sources/SnapshotPreviewsCore/View+Snapshot.swift
+++ b/Sources/SnapshotPreviewsCore/View+Snapshot.swift
@@ -50,14 +50,14 @@ extension View {
     a11yWrapper: ((UIViewController, UIWindow, PreviewLayout) -> UIView)? = nil,
     completion: @escaping (SnapshotResult) -> Void)
   {
-    controller.expansionSettled = { [weak controller, weak window] renderingMode, precision, accessibilityEnabled, appStoreSnapshot, error in
+    controller.expansionSettled = { [weak controller, weak window] renderingMode, precision, accessibilityEnabled, appStoreSnapshot, tags, additionalContext, error in
       guard let controller, let window, let containerVC = controller.parent else {
         return
       }
 
       if let error {
         DispatchQueue.main.async {
-          completion(SnapshotResult(image: .failure(error), precision: precision, accessibilityEnabled: accessibilityEnabled, colorScheme: _colorScheme, appStoreSnapshot: appStoreSnapshot))
+          completion(SnapshotResult(image: .failure(error), precision: precision, accessibilityEnabled: accessibilityEnabled, colorScheme: _colorScheme, appStoreSnapshot: appStoreSnapshot, tags: tags, additionalContext: additionalContext))
         }
         return
       }
@@ -65,7 +65,7 @@ extension View {
       if async {
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
           let imageResult = Self.takeSnapshot(layout: layout, renderingMode: renderingMode, window: window, rootVC: containerVC, targetView: controller.view)
-          completion(SnapshotResult(image: imageResult.mapError { $0 }, precision: precision, accessibilityEnabled: accessibilityEnabled, colorScheme: _colorScheme, appStoreSnapshot: appStoreSnapshot))
+          completion(SnapshotResult(image: imageResult.mapError { $0 }, precision: precision, accessibilityEnabled: accessibilityEnabled, colorScheme: _colorScheme, appStoreSnapshot: appStoreSnapshot, tags: tags, additionalContext: additionalContext))
         }
       } else {
         DispatchQueue.main.async {
@@ -73,10 +73,10 @@ extension View {
             let a11yView = a11yWrapper(controller, window, layout)
             let result = Self.takeSnapshot(layout: .sizeThatFits, renderingMode: renderingMode, window: window, rootVC: containerVC, targetView: a11yView)
             a11yView.removeFromSuperview()
-            completion(SnapshotResult(image: result.mapError { $0 }, precision: precision, accessibilityEnabled: accessibilityEnabled, colorScheme: _colorScheme, appStoreSnapshot: appStoreSnapshot))
+            completion(SnapshotResult(image: result.mapError { $0 }, precision: precision, accessibilityEnabled: accessibilityEnabled, colorScheme: _colorScheme, appStoreSnapshot: appStoreSnapshot, tags: tags, additionalContext: additionalContext))
           } else {
             let imageResult = Self.takeSnapshot(layout: layout, renderingMode: renderingMode, window: window, rootVC: containerVC, targetView: controller.view)
-            completion(SnapshotResult(image: imageResult.mapError { $0 }, precision: precision, accessibilityEnabled: accessibilityEnabled, colorScheme: _colorScheme, appStoreSnapshot: appStoreSnapshot))
+            completion(SnapshotResult(image: imageResult.mapError { $0 }, precision: precision, accessibilityEnabled: accessibilityEnabled, colorScheme: _colorScheme, appStoreSnapshot: appStoreSnapshot, tags: tags, additionalContext: additionalContext))
           }
         }
       }

--- a/Sources/SnapshotSharedModels/SnapshotMetadataValue.swift
+++ b/Sources/SnapshotSharedModels/SnapshotMetadataValue.swift
@@ -1,0 +1,84 @@
+//
+//  SnapshotMetadataValue.swift
+//
+
+import CoreFoundation
+import CoreGraphics
+import Foundation
+
+public enum SnapshotMetadataValue: Sendable, Equatable, Encodable {
+  case string(String)
+  case number(Double)
+  case bool(Bool)
+  case object([String: SnapshotMetadataValue])
+
+  public init(_ value: Any) {
+    switch value {
+    case let value as SnapshotMetadataValue:
+      self = value
+    case let value as String:
+      self = .string(value)
+    case let value as Bool:
+      self = .bool(value)
+    case let value as Int:
+      self = Self.jsonNumber(Double(value))
+    case let value as Int8:
+      self = Self.jsonNumber(Double(value))
+    case let value as Int16:
+      self = Self.jsonNumber(Double(value))
+    case let value as Int32:
+      self = Self.jsonNumber(Double(value))
+    case let value as Int64:
+      self = Self.jsonNumber(Double(value))
+    case let value as UInt:
+      self = Self.jsonNumber(Double(value))
+    case let value as UInt8:
+      self = Self.jsonNumber(Double(value))
+    case let value as UInt16:
+      self = Self.jsonNumber(Double(value))
+    case let value as UInt32:
+      self = Self.jsonNumber(Double(value))
+    case let value as UInt64:
+      self = Self.jsonNumber(Double(value))
+    case let value as Double:
+      self = Self.jsonNumber(value)
+    case let value as Float:
+      self = Self.jsonNumber(Double(value))
+    case let value as CGFloat:
+      self = Self.jsonNumber(Double(value))
+    case let value as NSNumber:
+      if CFGetTypeID(value as CFTypeRef) == CFBooleanGetTypeID() {
+        self = .bool(value.boolValue)
+      } else {
+        self = Self.jsonNumber(value.doubleValue)
+      }
+    case let value as [String: Any]:
+      self = .object(Self.dictionary(from: value))
+    default:
+      preconditionFailure("Unsupported snapshot metadata value: \(type(of: value))")
+    }
+  }
+
+  public static func dictionary(from values: [String: Any]) -> [String: SnapshotMetadataValue] {
+    values.mapValues { SnapshotMetadataValue($0) }
+  }
+
+  private static func jsonNumber(_ value: Double) -> SnapshotMetadataValue {
+    precondition(value.isFinite, "Snapshot metadata numbers must be finite JSON values.")
+    return .number(value)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .string(let value):
+      try container.encode(value)
+    case .number(let value):
+      try container.encode(value)
+    case .bool(let value):
+      try container.encode(value)
+    case .object(let value):
+      try container.encode(value)
+    }
+  }
+}

--- a/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
+++ b/Sources/SnapshottingTests/SnapshotCIExportCoordinator.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import XCTest
+import SnapshotSharedModels
 @_implementationOnly import SnapshotPreviewsCore
 
 // MARK: - Snapshot Context
@@ -27,79 +28,120 @@ struct SnapshotContext: Sendable {
   let diffThreshold: Float?
   let accessibilityEnabled: Bool?
   let colorScheme: String?
+  let tags: [String: String]
+  let additionalContext: [String: SnapshotMetadataValue]
 }
 
 // MARK: - Sidecar Model
+
+private enum SnapshotSidecarContextKey {
+  /// The XCTest test name that produced this snapshot.
+  static let testName = "test_name"
+  /// Whether the snapshot was rendered with accessibility metadata enabled.
+  static let accessibilityEnabled = "accessibility_enabled"
+  /// Simulator metadata for the device that rendered this snapshot.
+  static let simulator = "simulator"
+  /// Preview metadata for the SwiftUI preview that produced this snapshot.
+  static let preview = "preview"
+
+  enum Simulator {
+    /// Human-readable simulator device name, if available.
+    static let deviceName = "device_name"
+    /// Simulator model identifier, if available.
+    static let modelIdentifier = "model_identifier"
+  }
+
+  enum Preview {
+    /// The preview's zero-based index within its container.
+    static let index = "index"
+    /// The author-declared `.previewDisplayName(...)` value, if set.
+    static let displayName = "display_name"
+    /// Fully-qualified type name of the container that declared this preview
+    /// (the `PreviewProvider` struct, or the compiler-synthesized `PreviewRegistry`
+    /// conformance for a `#Preview` macro).
+    static let containerTypeName = "container_type_name"
+    /// Human-readable label derived from the container's type name or file name.
+    /// Not author-declared — there's no SwiftUI API to set it.
+    static let containerDisplayName = "container_display_name"
+    /// The author-declared `.preferredColorScheme(_:)` value, if set. `"light"` or `"dark"`.
+    static let preferredColorScheme = "preferred_color_scheme"
+    /// The author-declared preview interface orientation (e.g. `"portrait"`, `"landscapeLeft"`).
+    /// Defaults to `"portrait"` when the author doesn't declare one.
+    static let orientation = "orientation"
+    /// The source line that declared the preview, if available.
+    static let line = "line"
+  }
+}
 
 private struct SnapshotSidecar: Sendable, Encodable {
   let displayName: String
   let group: String
   let diffThreshold: Float?
-  let context: Context
-
-  struct Context: Sendable, Encodable {
-    let testName: String
-    let accessibilityEnabled: Bool
-    let simulator: Simulator?
-    let preview: Preview
-
-    struct Simulator: Sendable, Encodable {
-      let deviceName: String?
-      let modelIdentifier: String?
-    }
-    
-    struct Preview: Sendable, Encodable {
-      let index: Int
-      /// The author-declared `.previewDisplayName(...)` value, if set.
-      let displayName: String?
-      /// Fully-qualified type name of the container that declared this preview
-      /// (the `PreviewProvider` struct, or the compiler-synthesized `PreviewRegistry`
-      /// conformance for a `#Preview` macro).
-      let containerTypeName: String
-      /// Human-readable label derived from the container's type name or file name.
-      /// Not author-declared — there's no SwiftUI API to set it.
-      let containerDisplayName: String
-      /// The author-declared `.preferredColorScheme(_:)` value, if set. `"light"` or `"dark"`.
-      let preferredColorScheme: String?
-      /// The author-declared preview interface orientation (e.g. `"portrait"`, `"landscapeLeft"`).
-      /// Defaults to `"portrait"` when the author doesn't declare one.
-      let orientation: String?
-      let line: Int?
-    }
-  }
+  let tags: [String: String]?
+  let context: [String: SnapshotMetadataValue]
 
   init(
     context: SnapshotContext,
-    imageFileName: String,
     displayName: String,
     group: String
   ) {
     self.displayName = displayName
     self.group = group
     self.diffThreshold = context.diffThreshold
+    self.tags = context.tags.isEmpty ? nil : context.tags
 
-    let simulator: Context.Simulator? =
-      (context.simulatorDeviceName == nil && context.simulatorModelIdentifier == nil)
-      ? nil
-      : Context.Simulator(
-          deviceName: context.simulatorDeviceName,
-          modelIdentifier: context.simulatorModelIdentifier
-        )
+    var generatedContext: [String: SnapshotMetadataValue] = [
+      SnapshotSidecarContextKey.testName: .string(context.testName),
+      SnapshotSidecarContextKey.accessibilityEnabled: .bool(context.accessibilityEnabled ?? false),
+      SnapshotSidecarContextKey.preview: .object(Self.previewContext(from: context)),
+    ]
 
-    self.context = Context(
-      testName: context.testName,
-      accessibilityEnabled: context.accessibilityEnabled ?? false,
-      simulator: simulator,
-      preview: Context.Preview(
-        index: context.previewIndex,
-        displayName: context.previewDisplayName,
-        containerTypeName: context.typeName,
-        containerDisplayName: context.typeDisplayName,
-        preferredColorScheme: context.colorScheme,
-        orientation: context.orientation.isEmpty ? nil : context.orientation,
-        line: context.line
-      )
-    )
+    if let simulatorContext = Self.simulatorContext(from: context) {
+      generatedContext[SnapshotSidecarContextKey.simulator] = .object(simulatorContext)
+    }
+
+    generatedContext.merge(context.additionalContext, uniquingKeysWith: { _, userValue in userValue })
+    self.context = generatedContext
+  }
+
+  private static func simulatorContext(from context: SnapshotContext) -> [String: SnapshotMetadataValue]? {
+    var simulator: [String: SnapshotMetadataValue] = [:]
+
+    if let deviceName = context.simulatorDeviceName {
+      simulator[SnapshotSidecarContextKey.Simulator.deviceName] = .string(deviceName)
+    }
+
+    if let modelIdentifier = context.simulatorModelIdentifier {
+      simulator[SnapshotSidecarContextKey.Simulator.modelIdentifier] = .string(modelIdentifier)
+    }
+
+    return simulator.isEmpty ? nil : simulator
+  }
+
+  private static func previewContext(from context: SnapshotContext) -> [String: SnapshotMetadataValue] {
+    var preview: [String: SnapshotMetadataValue] = [
+      SnapshotSidecarContextKey.Preview.index: .number(Double(context.previewIndex)),
+      SnapshotSidecarContextKey.Preview.containerTypeName: .string(context.typeName),
+      SnapshotSidecarContextKey.Preview.containerDisplayName: .string(context.typeDisplayName),
+    ]
+
+    if let previewDisplayName = context.previewDisplayName {
+      preview[SnapshotSidecarContextKey.Preview.displayName] = .string(previewDisplayName)
+    }
+
+    if let colorScheme = context.colorScheme {
+      preview[SnapshotSidecarContextKey.Preview.preferredColorScheme] = .string(colorScheme)
+    }
+
+    if !context.orientation.isEmpty {
+      preview[SnapshotSidecarContextKey.Preview.orientation] = .string(context.orientation)
+    }
+
+    if let line = context.line {
+      preview[SnapshotSidecarContextKey.Preview.line] = .number(Double(line))
+    }
+
+    return preview
   }
 }
 
@@ -272,7 +314,6 @@ final class SnapshotCIExportCoordinator: NSObject, XCTestObservation {
 
       let sidecar = SnapshotSidecar(
         context: context,
-        imageFileName: context.baseFileName,
         displayName: displayName,
         group: group
       )

--- a/Sources/SnapshottingTests/SnapshotTest.swift
+++ b/Sources/SnapshottingTests/SnapshotTest.swift
@@ -305,7 +305,9 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
         simulatorModelIdentifier: ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"],
         diffThreshold: SnapshotCIExportCoordinator.diffThreshold(for: result.precision),
         accessibilityEnabled: result.accessibilityEnabled,
-        colorScheme: colorSchemeValue)
+        colorScheme: colorSchemeValue,
+        tags: result.tags,
+        additionalContext: result.additionalContext)
       coordinator.enqueueExport(result: result, context: context)
     } else {
       do {

--- a/Tests/SnapshotPreferencesTests/SnapshotMetadataPreferenceTests.swift
+++ b/Tests/SnapshotPreferencesTests/SnapshotMetadataPreferenceTests.swift
@@ -1,0 +1,55 @@
+//
+//  SnapshotMetadataPreferenceTests.swift
+//
+
+import XCTest
+@testable import SnapshotPreferences
+import SnapshotSharedModels
+
+final class SnapshotMetadataPreferenceTests: XCTestCase {
+  func testTagsPreferenceMergesWithLaterValuesWinning() {
+    var value = SnapshotTagsPreferenceKey.defaultValue
+
+    SnapshotTagsPreferenceKey.reduce(value: &value) {
+      ["component": "button", "state": "loading"]
+    }
+    SnapshotTagsPreferenceKey.reduce(value: &value) {
+      ["state": "loaded", "theme": "dark"]
+    }
+
+    XCTAssertEqual(value["component"], "button")
+    XCTAssertEqual(value["state"], "loaded")
+    XCTAssertEqual(value["theme"], "dark")
+  }
+
+  func testAdditionalContextPreferenceMergesWithLaterValuesWinning() {
+    var value = SnapshotAdditionalContextPreferenceKey.defaultValue
+
+    SnapshotAdditionalContextPreferenceKey.reduce(value: &value) {
+      ["test_name": .string("generated"), "attempt": .number(1)]
+    }
+    SnapshotAdditionalContextPreferenceKey.reduce(value: &value) {
+      ["test_name": .string("custom"), "is_retry": .bool(true)]
+    }
+
+    XCTAssertEqual(value["test_name"], .string("custom"))
+    XCTAssertEqual(value["attempt"], .number(1))
+    XCTAssertEqual(value["is_retry"], .bool(true))
+  }
+
+  func testMetadataValueConvertsSupportedPublicTypes() {
+    let metadata = SnapshotMetadataValue.dictionary(from: [
+      "string": "value",
+      "int": 1,
+      "double": 1.5,
+      "bool": true,
+      "nested": ["key": "nested-value"],
+    ])
+
+    XCTAssertEqual(metadata["string"], .string("value"))
+    XCTAssertEqual(metadata["int"], .number(1))
+    XCTAssertEqual(metadata["double"], .number(1.5))
+    XCTAssertEqual(metadata["bool"], .bool(true))
+    XCTAssertEqual(metadata["nested"], .object(["key": .string("nested-value")]))
+  }
+}

--- a/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
+++ b/Tests/SnapshottingTestsTests/SnapshotCIExportCoordinatorTests.swift
@@ -7,6 +7,7 @@ import Foundation
 import XCTest
 @testable import SnapshottingTests
 import SnapshotPreviewsCore
+import SnapshotSharedModels
 
 #if canImport(UIKit)
 import UIKit
@@ -316,6 +317,70 @@ final class SnapshotCIExportCoordinatorTests: XCTestCase {
     XCTAssertNil(json["orientation"])
   }
 
+  func testSidecarIncludesTagsWhenProvided() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(
+      baseFileName: "TestView_Tags",
+      tags: ["component": "button", "state": "loading"]
+    )
+
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+    let tags = try XCTUnwrap(json["tags"] as? [String: String])
+
+    XCTAssertEqual(tags["component"], "button")
+    XCTAssertEqual(tags["state"], "loading")
+  }
+
+  func testSidecarMergesAdditionalContext() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(
+      baseFileName: "TestView_AdditionalContext",
+      additionalContext: [
+        "screen": .string("checkout"),
+        "attempt": .number(2),
+        "is_retry": .bool(true),
+        "fixture": .object([
+          "name": .string("happy-path"),
+          "version": .number(3),
+        ]),
+      ]
+    )
+
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+    let nestedContext = try XCTUnwrap(json["context"] as? [String: Any])
+    let fixture = try XCTUnwrap(nestedContext["fixture"] as? [String: Any])
+
+    XCTAssertEqual(nestedContext["screen"] as? String, "checkout")
+    XCTAssertEqual(nestedContext["attempt"] as? Double, 2)
+    XCTAssertEqual(nestedContext["is_retry"] as? Bool, true)
+    XCTAssertEqual(fixture["name"] as? String, "happy-path")
+    XCTAssertEqual(fixture["version"] as? Double, 3)
+  }
+
+  func testAdditionalContextOverridesGeneratedContextKeys() throws {
+    let coordinator = SnapshotCIExportCoordinator(exportDirectoryURL: tempDir)
+    let context = makeContext(
+      baseFileName: "TestView_ContextOverride",
+      additionalContext: [
+        "test_name": .string("custom-test-name"),
+      ]
+    )
+
+    coordinator.enqueueExport(result: makeSuccessResult(), context: context)
+    coordinator.drain()
+
+    let json = try readJSON(forBaseFileName: context.baseFileName)
+    let nestedContext = try XCTUnwrap(json["context"] as? [String: Any])
+
+    XCTAssertEqual(nestedContext["test_name"] as? String, "custom-test-name")
+  }
+
   func testDiffThresholdIsDerivedFromPrecision() {
     XCTAssertEqual(SnapshotCIExportCoordinator.diffThreshold(for: 1.0) ?? .zero, 0.0, accuracy: 0.000_1)
     XCTAssertEqual(SnapshotCIExportCoordinator.diffThreshold(for: 0.8) ?? .zero, 0.2, accuracy: 0.000_1)
@@ -450,7 +515,9 @@ extension SnapshotCIExportCoordinatorTests {
     previewDisplayName: String? = "Preview",
     previewIndex: Int = 0,
     diffThreshold: Float? = nil,
-    colorScheme: String? = nil
+    colorScheme: String? = nil,
+    tags: [String: String] = [:],
+    additionalContext: [String: SnapshotMetadataValue] = [:]
   ) -> SnapshotContext {
     SnapshotContext(
       baseFileName: baseFileName,
@@ -466,7 +533,9 @@ extension SnapshotCIExportCoordinatorTests {
       simulatorModelIdentifier: nil,
       diffThreshold: diffThreshold,
       accessibilityEnabled: nil,
-      colorScheme: colorScheme
+      colorScheme: colorScheme,
+      tags: tags,
+      additionalContext: additionalContext
     )
   }
 


### PR DESCRIPTION
Add SwiftUI snapshot metadata modifiers that flow through SnapshotPreviews' existing preference, rendering, and sidecar export pipeline.

This gives preview authors a first-class way to attach Sentry Snapshots metadata at the preview site, instead of relying only on generated sidecar fields. The implementation keeps metadata collection on the current path: SwiftUI preference → modifier state → renderer → `SnapshotResult` → `SnapshotContext` → JSON sidecar.

## New modifiers

### `.snapshotTags([String: String])`

Adds string tags to the top-level sidecar metadata:

```swift
#Preview("Checkout") {
  CheckoutView()
    .snapshotTags([
      "area": "checkout",
      "state": "empty",
    ])
}
```

renders as:

```json
{
  "tags": {
    "area": "checkout",
    "state": "empty"
  }
}
```

Rules:
- Tags are string key-value pairs.
- Repeated `.snapshotTags(...)` modifiers merge their dictionaries.
- If the same tag key appears more than once, the later modifier wins.
- Empty tags are omitted from the sidecar JSON.

### `.snapshotAdditionalContext([String: Any])`

Adds custom structured metadata to the sidecar `context` object:

```swift
#Preview("Checkout") {
  CheckoutView()
    .snapshotAdditionalContext([
      "fixture": "empty-cart",
      "attempt": 2,
      "is_retry": false,
      "scenario": [
        "name": "guest-checkout",
        "version": 3,
      ],
    ])
}
```

renders as:

```json
{
  "context": {
    "test_name": "CheckoutSnapshotTests/testCheckout",
    "accessibility_enabled": false,
    "fixture": "empty-cart",
    "attempt": 2,
    "is_retry": false,
    "scenario": {
      "name": "guest-checkout",
      "version": 3
    },
    "preview": {
      "index": 0,
      "display_name": "Checkout"
    }
  }
}
```

Rules:
- Supported values are strings, finite numbers, booleans, and nested objects.
- Unsupported values, such as arrays, dates, URLs, and nulls, fail early instead of being silently dropped.
- Repeated `.snapshotAdditionalContext(...)` modifiers merge their dictionaries.
- If the same custom context key appears more than once, the later modifier wins.
- Custom context is shallow-merged into generated context.
- If custom context collides with generated keys such as `test_name` or `preview`, the custom value intentionally wins.
- Nested objects are replaced as whole values on collision; they are not deep-merged.

### `.snapshotDiffThreshold(Float?)`

Sets the per-snapshot visual diff threshold:

```swift
#Preview("Map") {
  MapView()
    .snapshotDiffThreshold(0.05)
}
```

renders as:

```json
{
  "diff_threshold": 0.05
}
```

Rules:
- The value is emitted as top-level `diff_threshold` in the sidecar JSON.
- `0.0` requires an exact visual match.
- `0.05` allows up to a 5% changed-pixel share before Sentry marks the snapshot as changed.
- Passing `nil` preserves the default behavior and omits the field.
- The previous modifier spelling remains available as a deprecated renamed alias for source compatibility, but examples and docs now use `.snapshotDiffThreshold(...)`.

## Generated context

SnapshotPreviews still adds generated context fields when values are available, including:

```json
{
  "context": {
    "test_name": "CheckoutSnapshotTests/testCheckout",
    "accessibility_enabled": false,
    "simulator": {
      "device_name": "iPhone 15 Pro",
      "model_identifier": "iPhone16,1"
    },
    "preview": {
      "index": 0,
      "display_name": "Checkout",
      "container_type_name": "CheckoutPreviewProvider",
      "container_display_name": "Checkout",
      "preferred_color_scheme": "dark",
      "orientation": "portrait",
      "line": 42
    }
  }
}
```

User-provided additional context is applied after these generated fields, so override behavior is explicit and predictable.

## Implementation notes

A new `SnapshotMetadataValue` model keeps public `[String: Any]` input JSON-safe before it crosses preference, rendering, concurrency, and encoding boundaries. This avoids passing raw `Any` through SwiftUI preference reduction or sidecar encoding while preserving the ergonomic modifier API.

The sidecar context is now built as a dynamic metadata dictionary rather than a fixed nested struct, which allows generated context and user context to share the same output object. Documented key constants preserve the existing DocC context-field notes near the JSON key definitions.