### PR TITLE
build: Add XCFramework binary distribution support

### DIFF
--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -11,8 +11,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Xcode select
         run: sudo xcode-select -s '/Applications/Xcode_15.4.app/Contents/Developer'
-      - name: Build xcframework
-        run: sh build.sh
+      - name: Build and validate xcframeworks
+        run: bash build.sh
+      - name: Smoke test iOS binary xcframework integration
+        run: ruby scripts/smoke_binary_integration_ios.rb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Xcode select
         run: sudo xcode-select -s '/Applications/Xcode_15.4.app/Contents/Developer'
       - name: Build TestApp
-        run: cd Examples && xcodebuild build -scheme DemoApp -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -project DemoApp/DemoApp.xcodeproj
+        run: cd Examples && xcodebuild build -scheme DemoApp -destination 'generic/platform=iOS Simulator' -project DemoApp/DemoApp.xcodeproj
       - name: Build Snapshotting
         run: xcodebuild build -scheme Snapshotting -sdk iphonesimulator -destination 'generic/platform=iOS Simulator'
       - name: Build SnapshottingTests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,25 +11,39 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Xcode select
         run: sudo xcode-select -s '/Applications/Xcode_15.4.app/Contents/Developer'
-      - name: Build xcframework
-        run: sh build.sh
-      - name: Zip SnapshottingTests xcframework
-        run: zip -r SnapshottingTests.xcframework.zip SnapshottingTests.xcframework
-      - name: Zip PreviewGallery xcframework
-        run: zip -r PreviewGallery.xcframework.zip PreviewGallery.xcframework
-      - name: Zip preivews support
-        run: (cd PreviewsSupport && zip -r PreviewsSupport.xcframework.zip PreviewsSupport.xcframework)
+      - name: Build and validate xcframeworks
+        run: bash build.sh
+      - name: Smoke test iOS binary xcframework integration
+        run: ruby scripts/smoke_binary_integration_ios.rb
+      - name: Zip xcframeworks
+        run: |
+          rm -f *.xcframework.zip
+          for framework in \
+            SnapshotSharedModels \
+            SnapshotPreviewsCore \
+            SnapshotPreferences \
+            PreviewGallery \
+            SnapshottingTests \
+            Snapshotting \
+            PreviewsSupport
+          do
+            (cd XCFrameworks && zip -r "../$framework.xcframework.zip" "$framework.xcframework")
+          done
       - name: Upload Artifact
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
+            SnapshotSharedModels.xcframework.zip
+            SnapshotPreviewsCore.xcframework.zip
+            SnapshotPreferences.xcframework.zip
             PreviewGallery.xcframework.zip
             SnapshottingTests.xcframework.zip
-            PreviewsSupport/PreviewsSupport.xcframework.zip
+            Snapshotting.xcframework.zip
+            PreviewsSupport.xcframework.zip
           body:
             Release ${{ github.ref }}
             Automated release created by GitHub Actions.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .DS_Store
+/build/
+/Package.resolved
+/XCFrameworks/
 /.build
 /Packages
 xcuserdata/

--- a/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/project.pbxproj
+++ b/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/project.pbxproj
@@ -7,6 +7,54 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8B2B491A2FD01D8B003221F3 /* SnapshottingTests.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */; };
+		8B2B491B2FD01D8B003221F3 /* SnapshottingTests.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B491C2FD01D94003221F3 /* PreviewGallery.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49122FD01D81003221F3 /* PreviewGallery.xcframework */; };
+		8B2B491D2FD01D94003221F3 /* PreviewGallery.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49122FD01D81003221F3 /* PreviewGallery.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B491F2FD01D9F003221F3 /* SnapshottingTests.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */; };
+		8B2B49202FD01D9F003221F3 /* SnapshottingTests.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49222FD01DAA003221F3 /* SnapshottingTests.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */; };
+		8B2B49232FD01DAA003221F3 /* SnapshottingTests.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49252FD01DB3003221F3 /* SnapshotPreferences.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */; };
+		8B2B49282FD01DBD003221F3 /* PreviewGallery.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49122FD01D81003221F3 /* PreviewGallery.xcframework */; };
+		8B2B49292FD01DBD003221F3 /* PreviewGallery.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49122FD01D81003221F3 /* PreviewGallery.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B492A2FD01DC1003221F3 /* SnapshotPreferences.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */; };
+		8B2B492B2FD01DC1003221F3 /* SnapshotPreferences.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B492C2FD01E1C003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; };
+		8B2B492D2FD01E1C003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B492E2FD01E23003221F3 /* SnapshotSharedModels.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; };
+		8B2B492F2FD01E23003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49312FD01E8B003221F3 /* PreviewsSupport.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; };
+		8B2B49322FD01EC1003221F3 /* SnapshotSharedModels.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; };
+		8B2B49342FD01EDD003221F3 /* PreviewsSupport.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; };
+		8B2B49352FD01EDD003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49362FD01EDD003221F3 /* SnapshotPreferences.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */; };
+		8B2B49372FD01EDD003221F3 /* SnapshotPreferences.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49382FD01EDD003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; };
+		8B2B49392FD01EDD003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B493A2FD01EDD003221F3 /* SnapshotSharedModels.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; };
+		8B2B493B2FD01EDD003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B493C2FD01F1B003221F3 /* PreviewsSupport.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; };
+		8B2B493D2FD01F1B003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B493E2FD01F1B003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; };
+		8B2B493F2FD01F1B003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49402FD01F1B003221F3 /* SnapshotSharedModels.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; };
+		8B2B49412FD01F1B003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49422FD01F30003221F3 /* PreviewsSupport.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; };
+		8B2B49432FD01F30003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49442FD01F30003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; };
+		8B2B49452FD01F30003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49462FD01F30003221F3 /* SnapshotSharedModels.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; };
+		8B2B49472FD01F30003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49482FD01F3A003221F3 /* PreviewsSupport.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; };
+		8B2B49492FD01F3A003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B494A2FD01F3A003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; };
+		8B2B494B2FD01F3A003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B494C2FD01F3A003221F3 /* SnapshotSharedModels.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; };
+		8B2B494D2FD01F3A003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B494E2FD09E01003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B494F2FD0A000003221F3 /* Snapshotting.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49162FD01D81003221F3 /* Snapshotting.xcframework */; };
+		8B2B49502FD0A000003221F3 /* Snapshotting.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49162FD01D81003221F3 /* Snapshotting.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FA0B20F12A7DA20200EC91D3 /* AnyViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0B20F02A7DA20200EC91D3 /* AnyViewPreview.swift */; };
 		FA0B20FA2A7DCB0100EC91D3 /* ArrayBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0B20F82A7DCB0100EC91D3 /* ArrayBuilder.swift */; };
 		FA0B20FB2A7DCB0100EC91D3 /* PreviewVariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0B20F92A7DCB0100EC91D3 /* PreviewVariants.swift */; };
@@ -28,31 +76,22 @@
 		FA1671FB2A53E03800A42DB0 /* MessageRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1671FA2A53E03800A42DB0 /* MessageRow.swift */; };
 		FA1671FD2A53E11E00A42DB0 /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1671FC2A53E11E00A42DB0 /* MessageView.swift */; };
 		FA1671FF2A53E1AF00A42DB0 /* ConversationMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1671FE2A53E1AF00A42DB0 /* ConversationMessageView.swift */; };
-		FA170AD32A8B3BA400D1D53D /* PreviewGallery in Frameworks */ = {isa = PBXBuildFile; productRef = FA170AD22A8B3BA400D1D53D /* PreviewGallery */; };
 		FA1E452E2ADF3C3D002C85DB /* UIViewPreviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1E452D2ADF3C3D002C85DB /* UIViewPreviews.swift */; };
 		FA309EC32C38D71C00C85FF4 /* DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA309EC22C38D71C00C85FF4 /* DemoApp.swift */; };
 		FA309EC52C38D71C00C85FF4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA309EC42C38D71C00C85FF4 /* ContentView.swift */; };
 		FA309EC72C38D71D00C85FF4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FA309EC62C38D71D00C85FF4 /* Assets.xcassets */; };
 		FA309ECA2C38D71D00C85FF4 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FA309EC92C38D71D00C85FF4 /* Preview Assets.xcassets */; };
 		FA309ECD2C38D71D00C85FF4 /* Demo Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = FA309EC02C38D71C00C85FF4 /* Demo Watch App.app */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		FA309EE22C38D7A900C85FF4 /* Snapshotting in Frameworks */ = {isa = PBXBuildFile; productRef = FA309EE12C38D7A900C85FF4 /* Snapshotting */; };
-		FA309EE32C38D7A900C85FF4 /* Snapshotting in Embed Frameworks */ = {isa = PBXBuildFile; productRef = FA309EE12C38D7A900C85FF4 /* Snapshotting */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		FA309EE62C38D7AC00C85FF4 /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = FA309EE52C38D7AC00C85FF4 /* SnapshottingTests */; };
 		FA309EE72C38EB9B00C85FF4 /* DemoWatchAccessibilityPreviewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA309ED82C38D77C00C85FF4 /* DemoWatchAccessibilityPreviewTest.swift */; };
-		FA309EFE2C3EF68A00C85FF4 /* PreviewGallery in Frameworks */ = {isa = PBXBuildFile; productRef = FA309EFD2C3EF68A00C85FF4 /* PreviewGallery */; };
 		FA40515D2A95B587007A66D4 /* EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA40515C2A95B587007A66D4 /* EmptyView.swift */; };
 		FA5E82972A96448A008DE3F0 /* StateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5E82962A96448A008DE3F0 /* StateView.swift */; };
-		FA7EFE132B9235D100EF534F /* SnapshotPreferences in Frameworks */ = {isa = PBXBuildFile; productRef = FA7EFE122B9235D100EF534F /* SnapshotPreferences */; };
-		FA8E2F9E2E8D797000B7B9EB /* AccessibilitySnapshotCore in Frameworks */ = {isa = PBXBuildFile; productRef = FA8E2F9D2E8D797000B7B9EB /* AccessibilitySnapshotCore */; };
 		FA8F8B7E2C66C4C4007CEA33 /* DemoAppPreviewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8F8B7D2C66C4C4007CEA33 /* DemoAppPreviewTest.swift */; };
-		FA8F8B852C66C4CA007CEA33 /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = FA8F8B842C66C4CA007CEA33 /* SnapshottingTests */; };
 		FA9C8E442A56959300DC4574 /* RatingPreviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9C8E432A56959300DC4574 /* RatingPreviews.swift */; };
 		FAA4F4CF2B271D9C00127B63 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA4F4CE2B271D9C00127B63 /* Color.swift */; };
 		FABCCD932AC39081008F4D3A /* EMGTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABCCD922AC39081008F4D3A /* EMGTestHandler.swift */; };
 		FAC912372C894B6E00459191 /* OSVersionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC912362C894B6E00459191 /* OSVersionView.swift */; };
 		FACA23792A55FBEE0080545A /* DemoModule.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA1671D72A5399F700A42DB0 /* DemoModule.framework */; };
 		FACBADA32C67B8D60012D600 /* DemoWatchPreviewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACBADA22C67B8D60012D600 /* DemoWatchPreviewTest.swift */; };
-		FACBADAA2C67B8ED0012D600 /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = FACBADA92C67B8ED0012D600 /* SnapshottingTests */; };
 		FACBADAC2C67B9A50012D600 /* DemoWatchSnapshotTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACBADAB2C67B9A50012D600 /* DemoWatchSnapshotTest.swift */; };
 		FAD0107B2AA29ABA007D1AF6 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD0107A2AA29ABA007D1AF6 /* TextView.swift */; };
 		FAD52BF62A7B5EEA001F1832 /* ExpandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD52BF12A7B5EEA001F1832 /* ExpandingView.swift */; };
@@ -102,13 +141,61 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		8B2B491E2FD01D94003221F3 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				8B2B49372FD01EDD003221F3 /* SnapshotPreferences.xcframework in Embed Frameworks */,
+				8B2B49352FD01EDD003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */,
+				8B2B49392FD01EDD003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */,
+				8B2B491D2FD01D94003221F3 /* PreviewGallery.xcframework in Embed Frameworks */,
+				8B2B493B2FD01EDD003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B2B49212FD01D9F003221F3 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				8B2B49472FD01F30003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */,
+				8B2B49452FD01F30003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */,
+				8B2B49432FD01F30003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */,
+				8B2B49202FD01D9F003221F3 /* SnapshottingTests.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B2B49242FD01DAA003221F3 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				8B2B494D2FD01F3A003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */,
+				8B2B494B2FD01F3A003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */,
+				8B2B49492FD01F3A003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */,
+				8B2B49232FD01DAA003221F3 /* SnapshottingTests.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FA1671E22A5399F700A42DB0 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				8B2B492B2FD01DC1003221F3 /* SnapshotPreferences.xcframework in Embed Frameworks */,
 				FA1671DE2A5399F700A42DB0 /* DemoModule.framework in Embed Frameworks */,
+				8B2B494E2FD09E01003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */,
+				8B2B492D2FD01E1C003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */,
+				8B2B49292FD01DBD003221F3 /* PreviewGallery.xcframework in Embed Frameworks */,
+				8B2B492F2FD01E23003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -130,7 +217,11 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				FA309EE32C38D7A900C85FF4 /* Snapshotting in Embed Frameworks */,
+				8B2B49502FD0A000003221F3 /* Snapshotting.xcframework in Embed Frameworks */,
+				8B2B491B2FD01D8B003221F3 /* SnapshottingTests.xcframework in Embed Frameworks */,
+				8B2B493D2FD01F1B003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */,
+				8B2B493F2FD01F1B003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */,
+				8B2B49412FD01F1B003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -138,6 +229,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		8B2B49122FD01D81003221F3 /* PreviewGallery.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PreviewGallery.xcframework; path = ../../XCFrameworks/PreviewGallery.xcframework; sourceTree = "<group>"; };
+		8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SnapshotPreferences.xcframework; path = ../../XCFrameworks/SnapshotPreferences.xcframework; sourceTree = "<group>"; };
+		8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SnapshotPreviewsCore.xcframework; path = ../../XCFrameworks/SnapshotPreviewsCore.xcframework; sourceTree = "<group>"; };
+		8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SnapshotSharedModels.xcframework; path = ../../XCFrameworks/SnapshotSharedModels.xcframework; sourceTree = "<group>"; };
+		8B2B49162FD01D81003221F3 /* Snapshotting.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Snapshotting.xcframework; path = ../../XCFrameworks/Snapshotting.xcframework; sourceTree = "<group>"; };
+		8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SnapshottingTests.xcframework; path = ../../XCFrameworks/SnapshottingTests.xcframework; sourceTree = "<group>"; };
+		8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PreviewsSupport.xcframework; path = ../../XCFrameworks/PreviewsSupport.xcframework; sourceTree = "<group>"; };
 		C39F81522C6ABB7A004C7D57 /* DemoAppTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = DemoAppTests.xctestplan; sourceTree = "<group>"; };
 		FA0B20F02A7DA20200EC91D3 /* AnyViewPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyViewPreview.swift; sourceTree = "<group>"; };
 		FA0B20F82A7DCB0100EC91D3 /* ArrayBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayBuilder.swift; sourceTree = "<group>"; };
@@ -190,7 +288,6 @@
 		FAD52BF42A7B5EEA001F1832 /* RideShareButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RideShareButton.swift; sourceTree = "<group>"; };
 		FAD52BF52A7B5EEA001F1832 /* RideOptionsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RideOptionsView.swift; sourceTree = "<group>"; };
 		FADB112B2C67A17500985C48 /* DemoAppSnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppSnapshotTest.swift; sourceTree = "<group>"; };
-		FAF1BA622A54934200AEBE1B /* .. */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = ..; path = ../../..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -198,8 +295,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA170AD32A8B3BA400D1D53D /* PreviewGallery in Frameworks */,
+				8B2B492A2FD01DC1003221F3 /* SnapshotPreferences.xcframework in Frameworks */,
+				8B2B49282FD01DBD003221F3 /* PreviewGallery.xcframework in Frameworks */,
+				8B2B492C2FD01E1C003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */,
 				FACA23792A55FBEE0080545A /* DemoModule.framework in Frameworks */,
+				8B2B49312FD01E8B003221F3 /* PreviewsSupport.xcframework in Frameworks */,
+				8B2B492E2FD01E23003221F3 /* SnapshotSharedModels.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -207,7 +308,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA7EFE132B9235D100EF534F /* SnapshotPreferences in Frameworks */,
+				8B2B49322FD01EC1003221F3 /* SnapshotSharedModels.xcframework in Frameworks */,
+				8B2B49252FD01DB3003221F3 /* SnapshotPreferences.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -215,7 +317,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA309EFE2C3EF68A00C85FF4 /* PreviewGallery in Frameworks */,
+				8B2B49362FD01EDD003221F3 /* SnapshotPreferences.xcframework in Frameworks */,
+				8B2B49342FD01EDD003221F3 /* PreviewsSupport.xcframework in Frameworks */,
+				8B2B49382FD01EDD003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */,
+				8B2B491C2FD01D94003221F3 /* PreviewGallery.xcframework in Frameworks */,
+				8B2B493A2FD01EDD003221F3 /* SnapshotSharedModels.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -223,8 +329,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA309EE62C38D7AC00C85FF4 /* SnapshottingTests in Frameworks */,
-				FA309EE22C38D7A900C85FF4 /* Snapshotting in Frameworks */,
+				8B2B494F2FD0A000003221F3 /* Snapshotting.xcframework in Frameworks */,
+				8B2B491A2FD01D8B003221F3 /* SnapshottingTests.xcframework in Frameworks */,
+				8B2B493C2FD01F1B003221F3 /* PreviewsSupport.xcframework in Frameworks */,
+				8B2B493E2FD01F1B003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */,
+				8B2B49402FD01F1B003221F3 /* SnapshotSharedModels.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -232,8 +341,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA8E2F9E2E8D797000B7B9EB /* AccessibilitySnapshotCore in Frameworks */,
-				FA8F8B852C66C4CA007CEA33 /* SnapshottingTests in Frameworks */,
+				8B2B49462FD01F30003221F3 /* SnapshotSharedModels.xcframework in Frameworks */,
+				8B2B49442FD01F30003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */,
+				8B2B49422FD01F30003221F3 /* PreviewsSupport.xcframework in Frameworks */,
+				8B2B491F2FD01D9F003221F3 /* SnapshottingTests.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -241,7 +352,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FACBADAA2C67B8ED0012D600 /* SnapshottingTests in Frameworks */,
+				8B2B494C2FD01F3A003221F3 /* SnapshotSharedModels.xcframework in Frameworks */,
+				8B2B494A2FD01F3A003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */,
+				8B2B49482FD01F3A003221F3 /* PreviewsSupport.xcframework in Frameworks */,
+				8B2B49222FD01DAA003221F3 /* SnapshottingTests.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -253,12 +367,12 @@
 			children = (
 				C39F81522C6ABB7A004C7D57 /* DemoAppTests.xctestplan */,
 				FA44246E2AAA5B27005BFCD9 /* DemoApp.xctestplan */,
-				FA1671C12A5367A800A42DB0 /* DemoApp */,
-				FA1671D82A5399F700A42DB0 /* DemoModule */,
-				FA309EC12C38D71C00C85FF4 /* Demo Watch App */,
-				FA309ED72C38D77C00C85FF4 /* DemoWatchTests */,
-				FA8F8B7C2C66C4C4007CEA33 /* DemoAppTests */,
-				FACBADA12C67B8D60012D600 /* Demo Watch AppTests */,
+				FA1671C12A5367A800A42DB0 /* ../DemoApp/DemoApp */,
+				FA1671D82A5399F700A42DB0 /* ../DemoApp/DemoModule */,
+				FA309EC12C38D71C00C85FF4 /* ../DemoApp/Demo Watch App */,
+				FA309ED72C38D77C00C85FF4 /* ../DemoApp/DemoWatchTests */,
+				FA8F8B7C2C66C4C4007CEA33 /* ../DemoApp/DemoAppTests */,
+				FACBADA12C67B8D60012D600 /* ../DemoApp/Demo Watch AppTests */,
 				FA1671C02A5367A800A42DB0 /* Products */,
 				FA6E72BD2A54944800448463 /* Frameworks */,
 			);
@@ -277,10 +391,9 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		FA1671C12A5367A800A42DB0 /* DemoApp */ = {
+		FA1671C12A5367A800A42DB0 /* ../DemoApp/DemoApp */ = {
 			isa = PBXGroup;
 			children = (
-				FAF1BA622A54934200AEBE1B /* .. */,
 				FA1671C22A5367A800A42DB0 /* DemoAppApp.swift */,
 				FABCCD922AC39081008F4D3A /* EMGTestHandler.swift */,
 				FA1671C42A5367A800A42DB0 /* ContentView.swift */,
@@ -289,7 +402,7 @@
 				FA1671C82A5367A800A42DB0 /* DemoApp.entitlements */,
 				FA1671C92A5367A800A42DB0 /* Preview Content */,
 			);
-			path = DemoApp;
+			path = ../DemoApp/DemoApp;
 			sourceTree = "<group>";
 		};
 		FA1671C92A5367A800A42DB0 /* Preview Content */ = {
@@ -300,7 +413,7 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
-		FA1671D82A5399F700A42DB0 /* DemoModule */ = {
+		FA1671D82A5399F700A42DB0 /* ../DemoApp/DemoModule */ = {
 			isa = PBXGroup;
 			children = (
 				FA1671D92A5399F700A42DB0 /* DemoModule.h */,
@@ -319,10 +432,10 @@
 				FA1671FE2A53E1AF00A42DB0 /* ConversationMessageView.swift */,
 				FA13B8EE2B3E8B3300F58836 /* DateView.swift */,
 			);
-			path = DemoModule;
+			path = ../DemoApp/DemoModule;
 			sourceTree = "<group>";
 		};
-		FA309EC12C38D71C00C85FF4 /* Demo Watch App */ = {
+		FA309EC12C38D71C00C85FF4 /* ../DemoApp/Demo Watch App */ = {
 			isa = PBXGroup;
 			children = (
 				FA309EC22C38D71C00C85FF4 /* DemoApp.swift */,
@@ -330,7 +443,7 @@
 				FA309EC62C38D71D00C85FF4 /* Assets.xcassets */,
 				FA309EC82C38D71D00C85FF4 /* Preview Content */,
 			);
-			path = "Demo Watch App";
+			path = "../DemoApp/Demo Watch App";
 			sourceTree = "<group>";
 		};
 		FA309EC82C38D71D00C85FF4 /* Preview Content */ = {
@@ -341,38 +454,45 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
-		FA309ED72C38D77C00C85FF4 /* DemoWatchTests */ = {
+		FA309ED72C38D77C00C85FF4 /* ../DemoApp/DemoWatchTests */ = {
 			isa = PBXGroup;
 			children = (
 				FA309ED82C38D77C00C85FF4 /* DemoWatchAccessibilityPreviewTest.swift */,
 			);
-			path = DemoWatchTests;
+			path = ../DemoApp/DemoWatchTests;
 			sourceTree = "<group>";
 		};
 		FA6E72BD2A54944800448463 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8B2B49122FD01D81003221F3 /* PreviewGallery.xcframework */,
+				8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */,
+				8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */,
+				8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */,
+				8B2B49162FD01D81003221F3 /* Snapshotting.xcframework */,
+				8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */,
+				8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */,
 				FACA23752A55FB970080545A /* XCTest.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		FA8F8B7C2C66C4C4007CEA33 /* DemoAppTests */ = {
+		FA8F8B7C2C66C4C4007CEA33 /* ../DemoApp/DemoAppTests */ = {
 			isa = PBXGroup;
 			children = (
 				FA8F8B7D2C66C4C4007CEA33 /* DemoAppPreviewTest.swift */,
 				FADB112B2C67A17500985C48 /* DemoAppSnapshotTest.swift */,
 			);
-			path = DemoAppTests;
+			path = ../DemoApp/DemoAppTests;
 			sourceTree = "<group>";
 		};
-		FACBADA12C67B8D60012D600 /* Demo Watch AppTests */ = {
+		FACBADA12C67B8D60012D600 /* ../DemoApp/Demo Watch AppTests */ = {
 			isa = PBXGroup;
 			children = (
 				FACBADA22C67B8D60012D600 /* DemoWatchPreviewTest.swift */,
 				FACBADAB2C67B9A50012D600 /* DemoWatchSnapshotTest.swift */,
 			);
-			path = "Demo Watch AppTests";
+			path = "../DemoApp/Demo Watch AppTests";
 			sourceTree = "<group>";
 		};
 		FAD52BF02A7B5EBB001F1832 /* TestViews */ = {
@@ -427,7 +547,6 @@
 			);
 			name = DemoApp;
 			packageProductDependencies = (
-				FA170AD22A8B3BA400D1D53D /* PreviewGallery */,
 			);
 			productName = DemoApp;
 			productReference = FA1671BF2A5367A800A42DB0 /* DemoApp.app */;
@@ -448,7 +567,6 @@
 			);
 			name = DemoModule;
 			packageProductDependencies = (
-				FA7EFE122B9235D100EF534F /* SnapshotPreferences */,
 			);
 			productName = DemoModule;
 			productReference = FA1671D72A5399F700A42DB0 /* DemoModule.framework */;
@@ -461,6 +579,7 @@
 				FA309EBC2C38D71C00C85FF4 /* Sources */,
 				FA309EBD2C38D71C00C85FF4 /* Frameworks */,
 				FA309EBE2C38D71C00C85FF4 /* Resources */,
+				8B2B491E2FD01D94003221F3 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -468,7 +587,6 @@
 			);
 			name = "Demo Watch App";
 			packageProductDependencies = (
-				FA309EFD2C3EF68A00C85FF4 /* PreviewGallery */,
 			);
 			productName = "Demo Watch App";
 			productReference = FA309EC02C38D71C00C85FF4 /* Demo Watch App.app */;
@@ -490,8 +608,6 @@
 			);
 			name = DemoWatchTests;
 			packageProductDependencies = (
-				FA309EE12C38D7A900C85FF4 /* Snapshotting */,
-				FA309EE52C38D7AC00C85FF4 /* SnapshottingTests */,
 			);
 			productName = Demo;
 			productReference = FA309ED62C38D77C00C85FF4 /* DemoWatchTests.xctest */;
@@ -504,6 +620,7 @@
 				FA8F8B772C66C4C4007CEA33 /* Sources */,
 				FA8F8B782C66C4C4007CEA33 /* Frameworks */,
 				FA8F8B792C66C4C4007CEA33 /* Resources */,
+				8B2B49212FD01D9F003221F3 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -512,8 +629,6 @@
 			);
 			name = DemoAppTests;
 			packageProductDependencies = (
-				FA8F8B842C66C4CA007CEA33 /* SnapshottingTests */,
-				FA8E2F9D2E8D797000B7B9EB /* AccessibilitySnapshotCore */,
 			);
 			productName = DemoAppTests;
 			productReference = FA8F8B7B2C66C4C4007CEA33 /* DemoAppTests.xctest */;
@@ -526,6 +641,7 @@
 				FACBAD9C2C67B8D60012D600 /* Sources */,
 				FACBAD9D2C67B8D60012D600 /* Frameworks */,
 				FACBAD9E2C67B8D60012D600 /* Resources */,
+				8B2B49242FD01DAA003221F3 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -534,7 +650,6 @@
 			);
 			name = "Demo Watch AppTests";
 			packageProductDependencies = (
-				FACBADA92C67B8ED0012D600 /* SnapshottingTests */,
 			);
 			productName = "Demo Watch AppTests";
 			productReference = FACBADA02C67B8D60012D600 /* Demo Watch AppTests.xctest */;
@@ -574,7 +689,7 @@
 					};
 				};
 			};
-			buildConfigurationList = FA1671BA2A5367A800A42DB0 /* Build configuration list for PBXProject "DemoApp" */;
+			buildConfigurationList = FA1671BA2A5367A800A42DB0 /* Build configuration list for PBXProject "DemoApp-XCFrameworks" */;
 			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -584,7 +699,6 @@
 			);
 			mainGroup = FA1671B62A5367A800A42DB0;
 			packageReferences = (
-				FA8E2F9C2E8D797000B7B9EB /* XCRemoteSwiftPackageReference "AccessibilitySnapshot" */,
 			);
 			productRefGroup = FA1671C02A5367A800A42DB0 /* Products */;
 			projectDirPath = "";
@@ -886,11 +1000,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = DemoApp/DemoApp.entitlements;
+				CODE_SIGN_ENTITLEMENTS = ../DemoApp/DemoApp/DemoApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"DemoApp/Preview Content\"";
-				DEVELOPMENT_TEAM = 62J2XHNK9T;
+				DEVELOPMENT_ASSET_PATHS = "\"../DemoApp/DemoApp/Preview Content\"";
+				DEVELOPMENT_TEAM = BR6WD3M6ZD;
 				ENABLE_DEBUG_DYLIB = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_PREVIEWS = YES;
@@ -914,12 +1028,12 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_DOCUMENTATION_COMPILER = YES;
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
-				SUPPORTS_MACCATALYST = YES;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -929,11 +1043,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = DemoApp/DemoApp.entitlements;
+				CODE_SIGN_ENTITLEMENTS = ../DemoApp/DemoApp/DemoApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"DemoApp/Preview Content\"";
-				DEVELOPMENT_TEAM = 62J2XHNK9T;
+				DEVELOPMENT_ASSET_PATHS = "\"../DemoApp/DemoApp/Preview Content\"";
+				DEVELOPMENT_TEAM = BR6WD3M6ZD;
 				ENABLE_DEBUG_DYLIB = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_PREVIEWS = YES;
@@ -957,12 +1071,12 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_DOCUMENTATION_COMPILER = YES;
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
-				SUPPORTS_MACCATALYST = YES;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -973,7 +1087,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = J9H72XH8P9;
+				DEVELOPMENT_TEAM = BR6WD3M6ZD;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -998,13 +1112,12 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1017,7 +1130,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = J9H72XH8P9;
+				DEVELOPMENT_TEAM = BR6WD3M6ZD;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1042,12 +1155,11 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1060,13 +1172,13 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"Demo Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = 62J2XHNK9T;
+				DEVELOPMENT_ASSET_PATHS = "\"../DemoApp/Demo Watch App/Preview Content\"";
+				DEVELOPMENT_TEAM = BR6WD3M6ZD;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Demo;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIDeviceFamily = 4;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKApplication = YES;
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.emerge.PreviewsDemoApp;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1093,13 +1205,13 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"Demo Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = 62J2XHNK9T;
+				DEVELOPMENT_ASSET_PATHS = "\"../DemoApp/Demo Watch App/Preview Content\"";
+				DEVELOPMENT_TEAM = BR6WD3M6ZD;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Demo;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIDeviceFamily = 4;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKApplication = YES;
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.emerge.PreviewsDemoApp;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1173,7 +1285,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1195,7 +1309,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1248,7 +1364,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		FA1671BA2A5367A800A42DB0 /* Build configuration list for PBXProject "DemoApp" */ = {
+		FA1671BA2A5367A800A42DB0 /* Build configuration list for PBXProject "DemoApp-XCFrameworks" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				FA1671CC2A5367A800A42DB0 /* Debug */,
@@ -1312,53 +1428,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		FA8E2F9C2E8D797000B7B9EB /* XCRemoteSwiftPackageReference "AccessibilitySnapshot" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/EmergeTools/AccessibilitySnapshot.git";
-			requirement = {
-				kind = exactVersion;
-				version = 1.0.2;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		FA170AD22A8B3BA400D1D53D /* PreviewGallery */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = PreviewGallery;
-		};
-		FA309EE12C38D7A900C85FF4 /* Snapshotting */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Snapshotting;
-		};
-		FA309EE52C38D7AC00C85FF4 /* SnapshottingTests */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SnapshottingTests;
-		};
-		FA309EFD2C3EF68A00C85FF4 /* PreviewGallery */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = PreviewGallery;
-		};
-		FA7EFE122B9235D100EF534F /* SnapshotPreferences */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SnapshotPreferences;
-		};
-		FA8E2F9D2E8D797000B7B9EB /* AccessibilitySnapshotCore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FA8E2F9C2E8D797000B7B9EB /* XCRemoteSwiftPackageReference "AccessibilitySnapshot" */;
-			productName = AccessibilitySnapshotCore;
-		};
-		FA8F8B842C66C4CA007CEA33 /* SnapshottingTests */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SnapshottingTests;
-		};
-		FACBADA92C67B8ED0012D600 /* SnapshottingTests */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SnapshottingTests;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = FA1671B72A5367A800A42DB0 /* Project object */;
 }

--- a/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/xcshareddata/xcschemes/Demo Watch App.xcscheme
+++ b/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/xcshareddata/xcschemes/Demo Watch App.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA309EBF2C38D71C00C85FF4"
+               BuildableName = "Demo Watch App.app"
+               BlueprintName = "Demo Watch App"
+               ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FACBAD9F2C67B8D60012D600"
+               BuildableName = "Demo Watch AppTests.xctest"
+               BlueprintName = "Demo Watch AppTests"
+               ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA309EBF2C38D71C00C85FF4"
+            BuildableName = "Demo Watch App.app"
+            BlueprintName = "Demo Watch App"
+            ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA309EBF2C38D71C00C85FF4"
+            BuildableName = "Demo Watch App.app"
+            BlueprintName = "Demo Watch App"
+            ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
+++ b/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA1671BE2A5367A800A42DB0"
+               BuildableName = "DemoApp.app"
+               BlueprintName = "DemoApp"
+               ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:DemoApp.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA1671BE2A5367A800A42DB0"
+            BuildableName = "DemoApp.app"
+            BlueprintName = "DemoApp"
+            ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA1671BE2A5367A800A42DB0"
+            BuildableName = "DemoApp.app"
+            BlueprintName = "DemoApp"
+            ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/xcshareddata/xcschemes/DemoAppTests.xcscheme
+++ b/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/xcshareddata/xcschemes/DemoAppTests.xcscheme
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:DemoAppTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA8F8B7A2C66C4C4007CEA33"
+               BuildableName = "DemoAppTests.xctest"
+               BlueprintName = "DemoAppTests"
+               ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/DemoApp-XCFrameworks/DemoApp.xctestplan
+++ b/Examples/DemoApp-XCFrameworks/DemoApp.xctestplan
@@ -1,0 +1,20 @@
+{
+  "configurations": [
+    {
+      "id": "FF846110-BFA2-419E-BF99-A9FC438920E2",
+      "name": "Configuration 1",
+      "options": {}
+    }
+  ],
+  "defaultOptions": {},
+  "testTargets": [
+    {
+      "target": {
+        "containerPath": "container:DemoApp-XCFrameworks.xcodeproj",
+        "identifier": "FA8F8B7A2C66C4C4007CEA33",
+        "name": "DemoAppTests"
+      }
+    }
+  ],
+  "version": 1
+}

--- a/Examples/DemoApp-XCFrameworks/DemoAppTests.xctestplan
+++ b/Examples/DemoApp-XCFrameworks/DemoAppTests.xctestplan
@@ -1,0 +1,20 @@
+{
+  "configurations": [
+    {
+      "id": "B1D580A7-404D-4E1D-80D8-0E56CDD58281",
+      "name": "Test Scheme Action",
+      "options": {}
+    }
+  ],
+  "defaultOptions": {},
+  "testTargets": [
+    {
+      "target": {
+        "containerPath": "container:DemoApp-XCFrameworks.xcodeproj",
+        "identifier": "FA8F8B7A2C66C4C4007CEA33",
+        "name": "DemoAppTests"
+      }
+    }
+  ],
+  "version": 1
+}

--- a/Examples/DemoApp-XCFrameworks/README.md
+++ b/Examples/DemoApp-XCFrameworks/README.md
@@ -1,0 +1,13 @@
+# DemoApp XCFrameworks Example
+
+This example uses the same demo sources as `Examples/DemoApp`, but links against locally generated XCFrameworks instead of the Swift package.
+
+Generate the frameworks before opening or building the project. This requires Xcode and Ruby because the wrapper script delegates to the repository-level Ruby XCFramework build tooling.
+
+```bash
+cd Examples/DemoApp-XCFrameworks
+./generate-xcframeworks.sh
+open DemoApp-XCFrameworks.xcodeproj
+```
+
+The project expects the generated artifacts in the repository root `XCFrameworks/` folder, for example `../../XCFrameworks/SnapshottingTests.xcframework` and `../../XCFrameworks/PreviewsSupport.xcframework`.

--- a/Examples/DemoApp-XCFrameworks/generate-xcframeworks.sh
+++ b/Examples/DemoApp-XCFrameworks/generate-xcframeworks.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+./build.sh

--- a/Examples/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/Demo Watch App.xcscheme
+++ b/Examples/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/Demo Watch App.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA309EBF2C38D71C00C85FF4"
+               BuildableName = "Demo Watch App.app"
+               BlueprintName = "Demo Watch App"
+               ReferencedContainer = "container:DemoApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FACBAD9F2C67B8D60012D600"
+               BuildableName = "Demo Watch AppTests.xctest"
+               BlueprintName = "Demo Watch AppTests"
+               ReferencedContainer = "container:DemoApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA309EBF2C38D71C00C85FF4"
+            BuildableName = "Demo Watch App.app"
+            BlueprintName = "Demo Watch App"
+            ReferencedContainer = "container:DemoApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA309EBF2C38D71C00C85FF4"
+            BuildableName = "Demo Watch App.app"
+            BlueprintName = "Demo Watch App"
+            ReferencedContainer = "container:DemoApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/DemoApp/DemoAppTests/DemoAppSnapshotTest.swift
+++ b/Examples/DemoApp/DemoAppTests/DemoAppSnapshotTest.swift
@@ -9,8 +9,10 @@ import Foundation
 #if canImport(UIKit)
 import UIKit
 #endif
-import SnapshottingTests
+#if canImport(AccessibilitySnapshotCore)
 import AccessibilitySnapshotCore
+#endif
+import SnapshottingTests
 
 class DemoAppSnapshotTest: SnapshotTest {
   override class func snapshotPreviews() -> [String]? {
@@ -28,8 +30,8 @@ class DemoAppSnapshotTest: SnapshotTest {
   override class func excludedSnapshotPreviewModules() -> [String]? {
     return nil
   }
-  
-  #if canImport(UIKit) && !os(watchOS) && !os(visionOS) && !os(tvOS)
+
+  #if canImport(UIKit) && canImport(AccessibilitySnapshotCore) && !os(watchOS) && !os(visionOS) && !os(tvOS)
   override open class func setupA11y() -> ((UIViewController, UIWindow, PreviewLayout) -> UIView)? {
     return { (controller: UIViewController, window: UIWindow, layout: PreviewLayout) in
       let containerVC = controller.parent
@@ -45,7 +47,7 @@ class DemoAppSnapshotTest: SnapshotTest {
         viewRenderingMode: controller.view.bounds.size.requiresCoreAnimationSnapshot ? .renderLayerInContext : .drawHierarchyInRect,
         activationPointDisplayMode: .never,
         showUserInputLabels: true)
-    
+
       a11yView.center = window.center
       window.addSubview(a11yView)
 
@@ -57,8 +59,10 @@ class DemoAppSnapshotTest: SnapshotTest {
   #endif
 }
 
+#if canImport(UIKit)
 extension CGSize {
   var requiresCoreAnimationSnapshot: Bool {
     height >= UIScreen.main.bounds.size.height * 2
   }
 }
+#endif

--- a/Examples/DemoApp/DemoWatchTests/DemoWatchAccessibilityPreviewTest.swift
+++ b/Examples/DemoApp/DemoWatchTests/DemoWatchAccessibilityPreviewTest.swift
@@ -5,7 +5,6 @@
 //  Created by Noah Martin on 7/5/24.
 //
 
-import Snapshotting
 import SnapshottingTests
 import XCTest
 

--- a/Package.swift
+++ b/Package.swift
@@ -10,13 +10,11 @@ let package = Package(
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
           name: "PreviewGallery",
-          type: .static, // Replace this to build dynamic
           targets: ["PreviewGallery"]),
         // Test library to import in your XCTest target.
         // This is the only library that depends on XCTest.framework
         .library(
           name: "SnapshottingTests",
-          type: .static, // Replace this to build dynamic
           targets: ["SnapshottingTests"]),
         // Link the main app to this target to use custom snapshot settings
         // This lib does not get inserted when running tests to avoid
@@ -28,6 +26,10 @@ let package = Package(
         .library(
           name: "SnapshotPreviewsCore",
           targets: ["SnapshotPreviewsCore"]),
+        // Shared models required by the binary framework distribution.
+        .library(
+          name: "SnapshotSharedModels",
+          targets: ["SnapshotSharedModels"]),
         // Dynamic library that your main app will have inserted to generate previews
         .library(
           name: "Snapshotting",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Generate snapshot images from your Xcode previews with zero test code, and export them to disk for upload to [Sentry Snapshots](https://docs.sentry.io/product/snapshots/) or any other visual diffing service. Works with SwiftUI and UIKit previews using `PreviewProvider` or `#Preview`, on all Apple platforms (iOS / macOS / watchOS / tvOS / visionOS).
 
-# Installation
+## Installation
 
 Add the package as a Swift Package Manager dependency using the repository URL:
 
@@ -19,7 +19,7 @@ https://github.com/EmergeTools/SnapshotPreviews
 
 Link your XCTest target to the `SnapshottingTests` product. If you also want to customize per-preview rendering (e.g. precision, layout) you can link `SnapshotPreferences` to your app target.
 
-# Generating Snapshots
+## Generating Snapshots
 
 Create a test class that inherits from `SnapshotTest`. There are no test functions to write — they're added at runtime, one per discovered preview:
 
@@ -44,7 +44,7 @@ By default each rendered preview is attached to the XCTest results bundle as a P
 
 ![Screenshot of Xcode test output](https://raw.githubusercontent.com/EmergeTools/SnapshotPreviews/master/images/testOutput.png)
 
-## Filtering by module
+### Filtering by module
 
 If your app links several frameworks, you can scope discovery to specific modules:
 
@@ -59,13 +59,13 @@ override class func excludedSnapshotPreviewModules() -> [String]? { ["LegacyModu
 > [!NOTE]
 > Preview macros (`#Preview("Display Name")`) produce snapshot names based on file path and display name, for example: `MyModule/MyFile.swift:Display Name`.
 
-# Uploading Snapshots to Sentry
+## Exporting snapshots for Sentry
 
 `SnapshotPreviews` is the recommended iOS feeder for [Sentry Snapshots](https://docs.sentry.io/product/snapshots/). The flow has two steps: `xcodebuild test` writes PNGs + JSON sidecars to a directory, then `sentry-cli build snapshots` uploads that directory.
 
 ![Sentry Snapshots visual diff UI](https://github.com/user-attachments/assets/3a9e5c84-7954-4e73-89a1-3e5a181b7c7c)
 
-## 1. Export the snapshots from your test run
+### 1. Export the snapshots from your test run
 
 Set `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR` on the test invocation. When set, `SnapshotTest` writes images directly to that directory instead of attaching them to the `.xcresult` bundle.
 
@@ -114,7 +114,7 @@ import SnapshotPreferences
 
 No Xcode code-coverage data (`.profraw` / `.profdata`) is written by the exporter — only the PNGs and sidecars. If you need code coverage from the same test run, enable it on the scheme as usual; coverage output goes to the `.xcresult` bundle independently.
 
-## 2. Upload to Sentry
+### 2. Upload to Sentry
 
 Choose one of the upload options below.
 
@@ -156,9 +156,9 @@ Use Sentry's Fastlane integration if your CI already uploads Apple artifacts thr
 
 See Sentry's [CI integration docs](https://docs.sentry.io/product/snapshots/integrating-into-ci/) for sharding across simulators and base/head SHA pinning.
 
-# Tips
+## Tips
 
-## Unique display names
+### Unique display names
 
 Give every preview a unique display name. This is what shows up in XCTest results and in the exported filenames / metadata:
 
@@ -176,11 +176,11 @@ struct MyView_Previews: PreviewProvider {
 
 Display names should be unique within each `PreviewProvider`, or within a file when using preview macros.
 
-## Snapshot best practices
+### Snapshot best practices
 
 Snapshot previews should be deterministic. Avoid live network calls, timers, animations that do not settle, locale-dependent data, and dates generated from the current clock. Prefer fixed fixtures and mocked dependencies so the same preview renders the same pixels in Xcode, local test runs, and CI.
 
-## Detecting the snapshot environment
+### Detecting the snapshot environment
 
 Set `SNAPSHOTS_RUNNING_FOR_PREVIEWS=1` in your unit test scheme to mirror the variable Xcode sets when rendering live previews. You can then disable preview-unfriendly behavior (logging, analytics, network calls) with a single check:
 
@@ -192,7 +192,7 @@ extension ProcessInfo {
 }
 ```
 
-## Snapshot modifiers
+### Snapshot modifiers
 
 Link the `SnapshotPreferences` product to your app target to customize individual previews before they are rendered by `SnapshotTest`.
 
@@ -205,7 +205,7 @@ Link the `SnapshotPreferences` product to your app target to customize individua
 | `.snapshotAdditionalContext(["fixture": "loaded"])` | You want extra sidecar metadata for debugging or filtering. | Adds fields to the JSON sidecar `context` object. Repeated context modifiers merge, and later duplicate keys win. Custom keys override generated context keys. |
 | `.snapshotDiffThreshold(0.05)` | A snapshot has small expected pixel differences. | Sets `diff_threshold` in the exported sidecar for this preview. `0.05` allows up to a 5% changed-pixel share before Sentry marks the image as changed. |
 
-## Variants
+### Variants
 
 > [!TIP]
 > `PreviewVariants` simplifies snapshot testing by ensuring a consistent set of variants and that every view has a name.
@@ -231,15 +231,50 @@ struct MyView_Previews: PreviewProvider {
 }
 ```
 
-# Additional Features
+## Additional Features
 
-## Preview rendering check (no PNGs)
+### Preview rendering check (no PNGs)
 
 If you only want to verify that every preview lays out without crashing — for example, to catch a missing `@EnvironmentObject` — inherit from `PreviewLayoutTest` instead of `SnapshotTest`. It runs the same discovery pipeline but skips the image render, so it's significantly faster. This gives you *preview coverage* (every preview was exercised); it does not produce Xcode code-coverage data.
 
-## Preview Gallery
+### Preview Gallery
 
 `PreviewGallery` is an interactive SwiftUI view that turns your previews into a browsable gallery of components — useful for internal builds where Xcode isn't available. Link your app to the `PreviewGallery` product and present it from wherever makes sense:
+
+> [!NOTE]
+> `PreviewGallery` discovers previews from runtime metadata in the built app. If no previews are present in that build, the gallery will open with no previews to display.
+
+#### Internal distribution builds
+
+`PreviewGallery` is designed for development and trusted internal distribution. If you want to include it in a TestFlight or other internal build, create a dedicated build configuration or archive scheme instead of changing your production Release configuration. The previews must both compile into that build and survive optimization:
+
+1. Link the app target to the `PreviewGallery` product.
+2. Configure Swift optimization so preview metadata is retained. Release configurations often use whole-module optimization, which can remove unreferenced preview declarations even when they compile successfully. For the internal gallery configuration, disable whole-module optimization or use a Debug-like compilation mode, then verify that the gallery shows the expected previews before distributing it.
+3. If your previews are wrapped in `#if DEBUG`, add a custom Swift compilation condition, such as `PREVIEW_GALLERY`, to the internal build configuration. In Xcode, set this under **Build Settings > Swift Compiler - Custom Flags > Active Compilation Conditions** (`SWIFT_ACTIVE_COMPILATION_CONDITIONS`). Then keep preview declarations compiled for Debug and that internal configuration:
+
+```swift
+#if DEBUG || PREVIEW_GALLERY
+#Preview {
+  MyView()
+}
+#endif
+```
+
+For `PreviewProvider` previews, wrap the provider type the same way:
+
+```swift
+#if DEBUG || PREVIEW_GALLERY
+struct MyView_Previews: PreviewProvider {
+  static var previews: some View {
+    MyView()
+  }
+}
+#endif
+```
+
+If your previews rely on assets, JSON fixtures, or other resources from a `Preview Content` folder, make sure those resources are included in the internal gallery build. Xcode Development Assets are intended for previews and Simulator development without increasing final app size, so they may not be present in builds you distribute.
+
+Only expose the gallery in trusted internal builds, and gate access appropriately, because previews can reveal unfinished UI, mock data, or internal states.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/EmergeTools/SnapshotPreviews/master/images/image1.png" />
@@ -263,7 +298,7 @@ struct InternalSettingsView: View {
 }
 ```
 
-## Accessibility audits
+### Accessibility audits
 
 Xcode [accessibility audits](https://developer.apple.com/documentation/xctest/xcuiapplication/4191487-performaccessibilityaudit) can run on every preview as part of a UI test. Inherit from `AccessibilityPreviewTest` and override the audit type / issue handler as needed:
 
@@ -293,11 +328,32 @@ See the demo app under `Examples/` for a full example.
   Previews are discovered in the test binary by parsing the `__swift5_proto` Mach-O section to find types that conform to `PreviewProvider` (and the related protocols generated by the `#Preview` macro). Background on how this works in the Swift runtime: [The Surprising Cost of Protocol Conformances in Swift](https://www.emergetools.com/blog/posts/SwiftProtocolConformance).
 </details>
 
-# Related Reading
+## Binary frameworks
+
+While Swift Package Manager is the recommended way to integrate SnapshotPreviews, every release also ships the frameworks as prebuilt XCFramework `.zip` assets:
+
+- `SnapshotPreferences.xcframework.zip` — user-facing SwiftUI preference modifiers.
+- `PreviewGallery.xcframework.zip` — user-facing preview gallery UI.
+- `SnapshottingTests.xcframework.zip` — user-facing XCTest snapshot and layout helpers.
+- `SnapshotSharedModels.xcframework.zip` — required support dependency shared by the public APIs.
+- `SnapshotPreviewsCore.xcframework.zip` — required support dependency for preview discovery and rendering.
+- `PreviewsSupport.xcframework.zip` — required binary support dependency for `SnapshotPreviewsCore`.
+- `Snapshotting.xcframework.zip` — compatibility/runtime artifact for inserted-dylib accessibility and UI-test workflows.
+
+Xcode does not infer transitive dependencies between manually added binary frameworks, so add the full dependency set for each target:
+
+- App target using per-preview rendering preferences: link and embed `SnapshotPreferences.xcframework` and `SnapshotSharedModels.xcframework`.
+- App target using the gallery UI: link and embed `PreviewGallery.xcframework`, `SnapshotPreviewsCore.xcframework`, `SnapshotPreferences.xcframework`, `SnapshotSharedModels.xcframework`, and `PreviewsSupport.xcframework`.
+- XCTest snapshot/layout target: link and embed `SnapshottingTests.xcframework`, `SnapshotPreviewsCore.xcframework`, `SnapshotSharedModels.xcframework`, and `PreviewsSupport.xcframework`.
+- Accessibility/UI-test target using the inserted-dylib flow: link and embed `SnapshottingTests.xcframework`, `Snapshotting.xcframework`, `SnapshotPreviewsCore.xcframework`, `SnapshotSharedModels.xcframework`, and `PreviewsSupport.xcframework`.
+
+You don't need to build anything to use the released artifacts above. You can build them locally from source using `bash build.sh` from the repository root. It requires Xcode and Ruby, writes the frameworks to `XCFrameworks/`, and validates the output.
+
+## Related Reading
 
 - [How to use VariadicView, SwiftUI's Private View API](https://www.emergetools.com/blog/posts/how-to-use-variadic-view) — `VariadicView` is how multiple images are rendered for one `PreviewProvider`.
 - [The Surprising Cost of Protocol Conformances in Swift](https://www.emergetools.com/blog/posts/SwiftProtocolConformance) — how preview types are discovered in app binaries.
 
-# Star History
+## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=EmergeTools/SnapshotPreviews&type=Date)](https://star-history.com/#EmergeTools/SnapshotPreviews&Date)

--- a/build.sh
+++ b/build.sh
@@ -1,62 +1,8 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd -P)"
-PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
 
-PROJECT_BUILD_DIR="${PROJECT_BUILD_DIR:-"${PROJECT_ROOT}/build"}"
-XCODEBUILD_BUILD_DIR="$PROJECT_BUILD_DIR/xcodebuild"
-XCODEBUILD_DERIVED_DATA_PATH="$XCODEBUILD_BUILD_DIR/DerivedData"
-
-build_framework() {
-    local sdk="$1"
-    local destination="$2"
-    local scheme="$3"
-
-    local XCODEBUILD_ARCHIVE_PATH="./$scheme-$sdk.xcarchive"
-
-    rm -rf "$XCODEBUILD_ARCHIVE_PATH"
-
-    xcodebuild archive \
-        -scheme $scheme \
-        -archivePath $XCODEBUILD_ARCHIVE_PATH \
-        -derivedDataPath "$XCODEBUILD_DERIVED_DATA_PATH" \
-        -sdk "$sdk" \
-        -destination "$destination" \
-        BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
-        INSTALL_PATH='Library/Frameworks' \
-        OTHER_SWIFT_FLAGS=-no-verify-emitted-module-interface
-
-    FRAMEWORK_MODULES_PATH="$XCODEBUILD_ARCHIVE_PATH/Products/Library/Frameworks/$scheme.framework/Modules"
-    mkdir -p "$FRAMEWORK_MODULES_PATH"
-    cp -r \
-    "$XCODEBUILD_DERIVED_DATA_PATH/Build/Intermediates.noindex/ArchiveIntermediates/$scheme/BuildProductsPath/Release-$sdk/$scheme.swiftmodule" \
-    "$FRAMEWORK_MODULES_PATH/$scheme.swiftmodule"
-    # Delete private swiftinterface
-    rm -f "$FRAMEWORK_MODULES_PATH/$scheme.swiftmodule/*.private.swiftinterface"
-    find "$FRAMEWORK_MODULES_PATH/$scheme.swiftmodule" -type f -name "*.swiftinterface" | while read -r file; do
-      # Remove lines containing "NSInvocation"
-      sed -e '/NSInvocation/d' -e 's/XCTest\.//g' "$file" > temp && mv temp "$file"
-    done
-
-}
-
-# Update the Package.swift to build the library as dynamic instead of static
-sed -i '' '/Replace this/ s/.*/type: .dynamic,/' Package.swift
-
-# Build SnapshottingTests
-build_framework "iphonesimulator" "generic/platform=iOS Simulator" "SnapshottingTests"
-build_framework "iphoneos" "generic/platform=iOS" "SnapshottingTests"
-
-# Build PreviewGallery
-build_framework "iphonesimulator" "generic/platform=iOS Simulator" "PreviewGallery"
-build_framework "iphoneos" "generic/platform=iOS" "PreviewGallery"
-
-echo "Builds completed successfully."
-
-rm -rf "SnapshottingTests.xcframework"
-xcodebuild -create-xcframework -framework SnapshottingTests-iphonesimulator.xcarchive/Products/Library/Frameworks/SnapshottingTests.framework -framework SnapshottingTests-iphoneos.xcarchive/Products/Library/Frameworks/SnapshottingTests.framework -output SnapshottingTests.xcframework
-
-rm -rf "PreviewGallery.xcframework"
-xcodebuild -create-xcframework -framework PreviewGallery-iphonesimulator.xcarchive/Products/Library/Frameworks/PreviewGallery.framework -framework PreviewGallery-iphoneos.xcarchive/Products/Library/Frameworks/PreviewGallery.framework -output PreviewGallery.xcframework
+ruby "$SCRIPT_DIR/scripts/build_xcframework_distribution.rb"
+ruby "$SCRIPT_DIR/scripts/validate_xcframework_distribution.rb"

--- a/scripts/build_xcframework_distribution.rb
+++ b/scripts/build_xcframework_distribution.rb
@@ -1,0 +1,276 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "find"
+require "open3"
+require_relative "xcframework_distribution"
+
+module XCFrameworkDistribution
+  class Builder
+    def initialize
+      configured_build_dir = ENV.fetch("PROJECT_BUILD_DIR", "build")
+      @project_build_dir = File.expand_path(configured_build_dir, ROOT)
+      @distribution_build_dir = File.join(@project_build_dir, "xcframework-distribution")
+      @temp_packages_dir = File.join(@distribution_build_dir, "temp-packages")
+      @xcodebuild_build_dir = File.join(@project_build_dir, "xcodebuild")
+    end
+
+    def run
+      validate_previews_support!
+      FileUtils.mkdir_p([@temp_packages_dir, DISTRIBUTION_DIR])
+      copy_previews_support_to_distribution
+      FRAMEWORKS.each { |framework| build_framework(framework) }
+      puts "XCFramework builds completed successfully in #{DISTRIBUTION_DIR}."
+    end
+
+    private
+
+    def validate_previews_support!
+      unless File.directory?(PREVIEWS_SUPPORT_XCFRAMEWORK)
+        abort "Missing #{PREVIEWS_SUPPORT_XCFRAMEWORK}. Run PreviewsSupport/build.sh or restore the checked-in artifact."
+      end
+
+      identifiers = XCFrameworkDistribution.available_libraries(PREVIEWS_SUPPORT_XCFRAMEWORK).map { |entry| entry.fetch("LibraryIdentifier") }
+      missing = XCFrameworkDistribution.required_platform_missing_identifiers(identifiers)
+      return if missing.empty?
+
+      formatted = missing.join(", ")
+      abort "PreviewsSupport.xcframework is missing required distribution slices: #{formatted}. Run PreviewsSupport/build.sh."
+    end
+
+    def copy_previews_support_to_distribution
+      destination = XCFrameworkDistribution.distributed_xcframework_path("PreviewsSupport")
+      FileUtils.rm_rf(destination)
+      FileUtils.cp_r(PREVIEWS_SUPPORT_XCFRAMEWORK, destination)
+    end
+
+    def build_framework(framework)
+      package_dir = File.join(@temp_packages_dir, framework.name)
+      archives_dir = File.join(package_dir, "archives")
+      derived_data_path = File.join(@xcodebuild_build_dir, "DerivedData", framework.name)
+
+      FileUtils.rm_rf(package_dir)
+      FileUtils.mkdir_p([archives_dir, File.join(package_dir, "Sources")])
+      copy_source_targets(framework, package_dir)
+      copy_binary_dependencies(framework, package_dir)
+      write_manifest(framework, package_dir)
+      validate_build_scheme!(framework, package_dir)
+
+      PLATFORMS.each do |platform|
+        archive_path = File.join(archives_dir, "#{framework.name}-#{platform.sdk}.xcarchive")
+        FileUtils.rm_rf(archive_path)
+        archive_framework(framework, platform, package_dir, archive_path, derived_data_path)
+        copy_swift_module(framework, platform.sdk, archive_path, derived_data_path)
+      end
+
+      create_xcframework(framework, archives_dir)
+      FileUtils.rm_rf(archives_dir)
+    end
+
+    def copy_source_targets(framework, package_dir)
+      framework.all_source_targets.each do |target|
+        source = File.join(ROOT, "Sources", target)
+        abort "Missing source target #{source}" unless File.directory?(source)
+
+        FileUtils.cp_r(source, File.join(package_dir, "Sources"))
+        include_dir = File.join(package_dir, "Sources", target, "include")
+        FileUtils.mkdir_p(include_dir) if framework.public_header_targets.include?(target)
+      end
+    end
+
+    def copy_binary_dependencies(framework, package_dir)
+      return if framework.all_binary_dependencies.empty?
+
+      binary_dir = File.join(package_dir, "BinaryDependencies")
+      FileUtils.mkdir_p(binary_dir)
+
+      framework.all_binary_dependencies.each do |dependency|
+        source = XCFrameworkDistribution.distributed_xcframework_path(dependency)
+        abort "Missing binary dependency #{dependency} for #{framework.name} at #{source}" unless File.directory?(source)
+
+        destination = File.join(binary_dir, "#{dependency}.xcframework")
+        FileUtils.rm_rf(destination)
+        FileUtils.cp_r(source, destination)
+      end
+    end
+
+    def write_manifest(framework, package_dir)
+      File.write(File.join(package_dir, "Package.swift"), manifest(framework))
+    end
+
+    def manifest(framework)
+      dependencies = framework.external_packages.map { |name| EXTERNAL_PACKAGES.fetch(name) }
+      binary_targets = framework.all_binary_dependencies.map do |name|
+        "        .binaryTarget(name: \"#{name}\", path: \"BinaryDependencies/#{name}.xcframework\")"
+      end
+      source_targets = framework.all_source_targets.map { |target| target_manifest(framework, target) }
+      targets = (binary_targets + source_targets).join(",\n")
+      dependency_block = dependencies.empty? ? "" : dependencies.map { |line| "      #{line}" }.join(",\n")
+
+      <<~SWIFT
+        // swift-tools-version: 5.7
+        import PackageDescription
+
+        let package = Package(
+            name: "#{framework.name}Distribution",
+            platforms: [.iOS(.v15), .macOS(.v12), .watchOS(.v9)],
+            products: [
+                .library(name: "#{framework.name}", type: .dynamic, targets: ["#{framework.name}"])
+            ],
+            dependencies: [
+        #{dependency_block}
+            ],
+            targets: [
+        #{targets}
+            ],
+            cxxLanguageStandard: .cxx11
+        )
+      SWIFT
+    end
+
+    def target_manifest(framework, target)
+      dependency_expressions = framework.target_dependencies.fetch(target, []).map { |dependency| swift_dependency_expression(dependency) }
+      attributes = ["name: \"#{target}\""]
+      attributes << "dependencies: [#{dependency_expressions.join(", ")}]" unless dependency_expressions.empty?
+      attributes << "publicHeadersPath: \"include\"" if framework.public_header_targets.include?(target)
+
+      linker_settings = linker_settings_for(framework, target)
+      attributes << "linkerSettings: #{linker_settings}" unless linker_settings.nil?
+
+      "        .target(#{attributes.join(", ")})"
+    end
+
+    def swift_dependency_expression(dependency)
+      dependency.start_with?(".") ? dependency : "\"#{dependency}\""
+    end
+
+    def linker_settings_for(framework, target)
+      return nil unless target == framework.name
+      return nil if framework.linker_retained_dependencies.empty?
+
+      flags = framework.linker_retained_dependencies.flat_map { |name| ["-Xlinker", "-needed_framework", "-Xlinker", name] }
+      swift_flags = flags.map { |flag| "\"#{flag}\"" }.join(", ")
+      "[.unsafeFlags([#{swift_flags}])]"
+    end
+
+    def validate_build_scheme!(framework, package_dir)
+      expected_scheme = build_scheme(framework)
+      command = ["xcodebuild", "-list", "-json"]
+      stdout, stderr, status = Dir.chdir(package_dir) { Open3.capture3(*command) }
+      unless status.success?
+        abort "Failed to inspect generated package schemes for #{framework.name}: #{stderr}"
+      end
+
+      available_schemes = package_schemes(stdout)
+      return if available_schemes.include?(expected_scheme)
+
+      formatted_schemes = available_schemes.empty? ? "none" : available_schemes.sort.join(", ")
+      abort "Generated package for #{framework.name} did not expose expected scheme #{expected_scheme.inspect}. Available schemes: #{formatted_schemes}. This build expects Xcode to expose the package scheme <Name>Distribution; do not switch to a product scheme without rerunning the package-scheme spike."
+    end
+
+    def package_schemes(xcodebuild_list_json)
+      parsed = JSON.parse(xcodebuild_list_json)
+      Array(parsed.dig("project", "schemes")) + Array(parsed.dig("workspace", "schemes"))
+    rescue JSON::ParserError => error
+      abort "Failed to parse xcodebuild -list -json output: #{error.message}"
+    end
+
+    def archive_framework(framework, platform, package_dir, archive_path, derived_data_path)
+      command = [
+        "xcodebuild", "archive",
+        "-scheme", build_scheme(framework),
+        "-archivePath", archive_path,
+        "-derivedDataPath", derived_data_path,
+        "-sdk", platform.sdk,
+        "-destination", platform.destination,
+        "BUILD_LIBRARY_FOR_DISTRIBUTION=YES",
+        "INSTALL_PATH=Library/Frameworks",
+        "SKIP_INSTALL=NO",
+        "OTHER_SWIFT_FLAGS=-no-verify-emitted-module-interface"
+      ]
+      run_command(command, chdir: package_dir)
+    end
+
+    def copy_swift_module(framework, sdk, archive_path, derived_data_path)
+      build_products_configuration = sdk == "macosx" ? "Release" : "Release-#{sdk}"
+      source_module_path = File.join(
+        derived_data_path,
+        "Build/Intermediates.noindex/ArchiveIntermediates/#{build_scheme(framework)}/BuildProductsPath",
+        build_products_configuration,
+        "#{framework.name}.swiftmodule"
+      )
+
+      unless File.directory?(source_module_path)
+        abort "Missing Swift module artifacts for #{framework.name} (#{sdk}) at #{source_module_path}" if framework.requires_swift_module
+        return
+      end
+
+      framework_path = File.join(archive_path, "Products/Library/Frameworks/#{framework.name}.framework")
+      modules_path = File.join(framework_path, "Modules")
+      versions_modules_path = File.join(framework_path, "Versions/A/Modules")
+      if sdk == "macosx" && File.directory?(File.join(framework_path, "Versions/A"))
+        modules_path = versions_modules_path
+        FileUtils.rm_rf(File.join(framework_path, "Modules"))
+        FileUtils.ln_s("Versions/Current/Modules", File.join(framework_path, "Modules"))
+      end
+
+      FileUtils.mkdir_p(modules_path)
+      destination = File.join(modules_path, "#{framework.name}.swiftmodule")
+      FileUtils.rm_rf(destination)
+      FileUtils.cp_r(source_module_path, destination)
+      sanitize_swift_interfaces(modules_path, framework.name)
+    end
+
+    def sanitize_swift_interfaces(modules_path, framework_name)
+      Find.find(modules_path) do |path|
+        next unless File.file?(path)
+
+        if path.end_with?(".private.swiftinterface")
+          FileUtils.rm_f(path)
+        elsif path.end_with?(".swiftinterface")
+          content = File.read(path)
+          File.write(path, sanitized_swift_interface(content, framework_name))
+        end
+      end
+    end
+
+    def sanitized_swift_interface(content, framework_name)
+      content.lines.each_with_object([]) do |line, sanitized_lines|
+        next if line.include?("NSInvocation")
+
+        sanitized_lines << sanitize_swift_interface_line(line, framework_name)
+      end.join
+    end
+
+    def sanitize_swift_interface_line(line, framework_name)
+      escaped_framework_name = Regexp.escape(framework_name)
+      line.gsub(/\bXCTest\.(?=[A-Z_])/, "")
+          .gsub(/\b#{escaped_framework_name}\.(?=[A-Z_])/, "")
+    end
+
+    def create_xcframework(framework, archives_dir)
+      output_path = XCFrameworkDistribution.distributed_xcframework_path(framework.name)
+      FileUtils.rm_rf(output_path)
+      command = ["xcodebuild", "-create-xcframework"]
+      PLATFORMS.each do |platform|
+        command << "-framework"
+        command << File.join(archives_dir, "#{framework.name}-#{platform.sdk}.xcarchive", "Products/Library/Frameworks/#{framework.name}.framework")
+      end
+      command << "-output" << output_path
+      run_command(command)
+    end
+
+    def build_scheme(framework)
+      "#{framework.name}Distribution"
+    end
+
+    def run_command(command, chdir: nil)
+      puts command.join(" ")
+      success = chdir.nil? ? system(*command) : Dir.chdir(chdir) { system(*command) }
+      abort "Command failed: #{command.join(" ")}" unless success
+    end
+  end
+end
+
+XCFrameworkDistribution::Builder.new.run

--- a/scripts/smoke_binary_integration_ios.rb
+++ b/scripts/smoke_binary_integration_ios.rb
@@ -1,0 +1,365 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "digest"
+require "fileutils"
+require "json"
+require "open3"
+require "shellwords"
+
+ROOT = File.expand_path("..", __dir__)
+BUILD_ROOT = File.expand_path(ENV.fetch("BINARY_SMOKE_BUILD_DIR", "build/binary-integration-smoke/ios"), ROOT)
+PROJECT_NAME = "BinarySmoke"
+APP_TARGET = "BinarySmokeApp"
+TEST_TARGET = "BinarySmokeTests"
+EXPORT_DIR = File.join(BUILD_ROOT, "snapshot-export")
+DERIVED_DATA_DIR = File.join(BUILD_ROOT, "DerivedData")
+RESULT_BUNDLE_PATH = File.join(BUILD_ROOT, "BinarySmoke.xcresult")
+FRAMEWORK_PATHS = {
+  "PreviewGallery" => File.join(ROOT, "XCFrameworks", "PreviewGallery.xcframework"),
+  "PreviewsSupport" => File.join(ROOT, "XCFrameworks", "PreviewsSupport.xcframework"),
+  "SnapshotPreferences" => File.join(ROOT, "XCFrameworks", "SnapshotPreferences.xcframework"),
+  "SnapshotPreviewsCore" => File.join(ROOT, "XCFrameworks", "SnapshotPreviewsCore.xcframework"),
+  "SnapshotSharedModels" => File.join(ROOT, "XCFrameworks", "SnapshotSharedModels.xcframework"),
+  "SnapshottingTests" => File.join(ROOT, "XCFrameworks", "SnapshottingTests.xcframework")
+}.freeze
+APP_FRAMEWORKS = %w[PreviewGallery SnapshotPreviewsCore SnapshotPreferences SnapshotSharedModels PreviewsSupport].freeze
+TEST_FRAMEWORKS = %w[SnapshottingTests SnapshotPreviewsCore SnapshotSharedModels PreviewsSupport].freeze
+FRAMEWORKS = (APP_FRAMEWORKS + TEST_FRAMEWORKS).uniq.freeze
+
+# Follow-up: add equivalent generated-project smokes for macOS and watchOS before release publication.
+
+Ref = Struct.new(:value)
+
+class SmokeProject
+  def initialize
+    @ids = {}
+    @objects = {}
+  end
+
+  def write
+    FileUtils.rm_rf(BUILD_ROOT)
+    FileUtils.mkdir_p([project_dir, workspace_dir, scheme_dir, app_dir, test_dir, EXPORT_DIR])
+    File.write(File.join(app_dir, "BinarySmokeApp.swift"), app_source)
+    File.write(File.join(test_dir, "BinarySmokeTests.swift"), test_source)
+    build_objects
+    File.write(File.join(project_dir, "project.pbxproj"), render_project)
+    File.write(File.join(workspace_dir, "contents.xcworkspacedata"), workspace)
+    File.write(File.join(scheme_dir, "#{PROJECT_NAME}.xcscheme"), scheme)
+  end
+
+  def project_path
+    project_dir
+  end
+
+  private
+
+  def project_dir
+    File.join(BUILD_ROOT, "#{PROJECT_NAME}.xcodeproj")
+  end
+
+  def scheme_dir
+    File.join(project_dir, "xcshareddata", "xcschemes")
+  end
+
+  def workspace_dir
+    File.join(project_dir, "project.xcworkspace")
+  end
+
+  def app_dir
+    File.join(BUILD_ROOT, APP_TARGET)
+  end
+
+  def test_dir
+    File.join(BUILD_ROOT, TEST_TARGET)
+  end
+
+  def id(label)
+    @ids[label] ||= "A#{Digest::MD5.hexdigest(label).upcase[0, 23]}"
+  end
+
+  def ref(label)
+    Ref.new(id(label))
+  end
+
+  def add(label, isa, attrs = {})
+    @objects[id(label)] = attrs.merge("isa" => isa)
+    ref(label)
+  end
+
+  def build_objects
+    app_source_file = add("app_source_file", "PBXFileReference", "lastKnownFileType" => "sourcecode.swift", "path" => "BinarySmokeApp.swift", "sourceTree" => "<group>")
+    test_source_file = add("test_source_file", "PBXFileReference", "lastKnownFileType" => "sourcecode.swift", "path" => "BinarySmokeTests.swift", "sourceTree" => "<group>")
+    app_product = add("app_product", "PBXFileReference", "explicitFileType" => "wrapper.application", "includeInIndex" => 0, "path" => "#{APP_TARGET}.app", "sourceTree" => "BUILT_PRODUCTS_DIR")
+    test_product = add("test_product", "PBXFileReference", "explicitFileType" => "wrapper.cfbundle", "includeInIndex" => 0, "path" => "#{TEST_TARGET}.xctest", "sourceTree" => "BUILT_PRODUCTS_DIR")
+    xctest_file = add("xctest_file", "PBXFileReference", "lastKnownFileType" => "wrapper.framework", "name" => "XCTest.framework", "path" => "Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework", "sourceTree" => "DEVELOPER_DIR")
+
+    framework_refs = FRAMEWORKS.to_h do |name|
+      [name, add("#{name}_file", "PBXFileReference", "lastKnownFileType" => "wrapper.xcframework", "name" => "#{name}.xcframework", "path" => FRAMEWORK_PATHS.fetch(name), "sourceTree" => "<absolute>")]
+    end
+
+    app_source_build = add("app_source_build", "PBXBuildFile", "fileRef" => app_source_file)
+    test_source_build = add("test_source_build", "PBXBuildFile", "fileRef" => test_source_file)
+    xctest_build = add("xctest_build", "PBXBuildFile", "fileRef" => xctest_file)
+    app_refs = framework_refs.slice(*APP_FRAMEWORKS)
+    test_refs = framework_refs.slice(*TEST_FRAMEWORKS)
+    app_link_builds = framework_builds("app_link", app_refs)
+    app_embed_builds = framework_builds("app_embed", app_refs, embed: true)
+    test_link_builds = framework_builds("test_link", test_refs)
+    test_embed_builds = framework_builds("test_embed", test_refs, embed: true)
+
+    app_sources = add("app_sources", "PBXSourcesBuildPhase", "buildActionMask" => 2_147_483_647, "files" => [app_source_build], "runOnlyForDeploymentPostprocessing" => 0)
+    test_sources = add("test_sources", "PBXSourcesBuildPhase", "buildActionMask" => 2_147_483_647, "files" => [test_source_build], "runOnlyForDeploymentPostprocessing" => 0)
+    app_frameworks = add("app_frameworks", "PBXFrameworksBuildPhase", "buildActionMask" => 2_147_483_647, "files" => app_link_builds, "runOnlyForDeploymentPostprocessing" => 0)
+    test_frameworks = add("test_frameworks", "PBXFrameworksBuildPhase", "buildActionMask" => 2_147_483_647, "files" => [xctest_build] + test_link_builds, "runOnlyForDeploymentPostprocessing" => 0)
+    app_embed = embed_phase("app_embed_phase", app_embed_builds)
+    test_embed = embed_phase("test_embed_phase", test_embed_builds)
+
+    app_group = add("app_group", "PBXGroup", "children" => [app_source_file], "path" => APP_TARGET, "sourceTree" => "<group>")
+    test_group = add("test_group", "PBXGroup", "children" => [test_source_file], "path" => TEST_TARGET, "sourceTree" => "<group>")
+    products_group = add("products_group", "PBXGroup", "children" => [app_product, test_product], "name" => "Products", "sourceTree" => "<group>")
+    frameworks_group = add("frameworks_group", "PBXGroup", "children" => framework_refs.values + [xctest_file], "name" => "Frameworks", "sourceTree" => "<group>")
+    main_group = add("main_group", "PBXGroup", "children" => [app_group, test_group, frameworks_group, products_group], "sourceTree" => "<group>")
+
+    project_config = configuration("project_debug", project_settings)
+    app_config = configuration("app_debug", app_settings)
+    test_config = configuration("test_debug", test_settings)
+    project_config_list = config_list("project_config_list", [project_config])
+    app_config_list = config_list("app_config_list", [app_config])
+    test_config_list = config_list("test_config_list", [test_config])
+
+    app_target = add("app_target", "PBXNativeTarget", "buildConfigurationList" => app_config_list, "buildPhases" => [app_sources, app_frameworks, app_embed], "buildRules" => [], "dependencies" => [], "name" => APP_TARGET, "productName" => APP_TARGET, "productReference" => app_product, "productType" => "com.apple.product-type.application")
+    app_proxy = add("app_proxy", "PBXContainerItemProxy", "containerPortal" => ref("project"), "proxyType" => 1, "remoteGlobalIDString" => id("app_target"), "remoteInfo" => APP_TARGET)
+    app_dependency = add("app_dependency", "PBXTargetDependency", "target" => app_target, "targetProxy" => app_proxy)
+    test_target = add("test_target", "PBXNativeTarget", "buildConfigurationList" => test_config_list, "buildPhases" => [test_sources, test_frameworks, test_embed], "buildRules" => [], "dependencies" => [app_dependency], "name" => TEST_TARGET, "productName" => TEST_TARGET, "productReference" => test_product, "productType" => "com.apple.product-type.bundle.unit-test")
+
+    add("project", "PBXProject", "attributes" => {
+      "BuildIndependentTargetsInParallel" => 1,
+      "LastSwiftUpdateCheck" => 1540,
+      "LastUpgradeCheck" => 1540,
+      "TargetAttributes" => { app_target => { "CreatedOnToolsVersion" => "15.4" }, test_target => { "CreatedOnToolsVersion" => "15.4", "TestTargetID" => app_target } }
+    }, "buildConfigurationList" => project_config_list, "compatibilityVersion" => "Xcode 14.0", "developmentRegion" => "en", "hasScannedForEncodings" => 0, "knownRegions" => %w[en Base], "mainGroup" => main_group, "productRefGroup" => products_group, "projectDirPath" => "", "projectRoot" => "", "targets" => [app_target, test_target])
+  end
+
+  def framework_builds(prefix, refs, embed: false)
+    refs.map do |name, file_ref|
+      attrs = { "fileRef" => file_ref }
+      attrs["settings"] = { "ATTRIBUTES" => %w[CodeSignOnCopy RemoveHeadersOnCopy] } if embed
+      add("#{prefix}_#{name}", "PBXBuildFile", attrs)
+    end
+  end
+
+  def embed_phase(label, files)
+    add(label, "PBXCopyFilesBuildPhase", "buildActionMask" => 2_147_483_647, "dstPath" => "", "dstSubfolderSpec" => 10, "files" => files, "name" => "Embed Frameworks", "runOnlyForDeploymentPostprocessing" => 0)
+  end
+
+  def configuration(label, settings)
+    add(label, "XCBuildConfiguration", "buildSettings" => settings, "name" => "Debug")
+  end
+
+  def config_list(label, configs)
+    add(label, "XCConfigurationList", "buildConfigurations" => configs, "defaultConfigurationIsVisible" => 0, "defaultConfigurationName" => "Debug")
+  end
+
+  def project_settings
+    { "ALWAYS_SEARCH_USER_PATHS" => "NO", "CLANG_ENABLE_MODULES" => "YES", "IPHONEOS_DEPLOYMENT_TARGET" => "15.0", "SDKROOT" => "iphoneos", "SUPPORTED_PLATFORMS" => "iphonesimulator iphoneos", "SWIFT_VERSION" => "5.0" }
+  end
+
+  def app_settings
+    project_settings.merge("CURRENT_PROJECT_VERSION" => "1", "GENERATE_INFOPLIST_FILE" => "YES", "INFOPLIST_KEY_UILaunchScreen_Generation" => "YES", "LD_RUNPATH_SEARCH_PATHS" => ["$(inherited)", "@executable_path/Frameworks"], "MARKETING_VERSION" => "1.0", "PRODUCT_BUNDLE_IDENTIFIER" => "com.emergetools.SnapshotPreviews.BinarySmoke", "PRODUCT_NAME" => "$(TARGET_NAME)", "SWIFT_EMIT_LOC_STRINGS" => "NO", "TARGETED_DEVICE_FAMILY" => "1")
+  end
+
+  def test_settings
+    project_settings.merge("BUNDLE_LOADER" => "$(TEST_HOST)", "CURRENT_PROJECT_VERSION" => "1", "ENABLE_TESTING_SEARCH_PATHS" => "YES", "GENERATE_INFOPLIST_FILE" => "YES", "LD_RUNPATH_SEARCH_PATHS" => ["$(inherited)", "@executable_path/Frameworks", "@loader_path/Frameworks"], "MARKETING_VERSION" => "1.0", "PRODUCT_BUNDLE_IDENTIFIER" => "com.emergetools.SnapshotPreviews.BinarySmokeTests", "PRODUCT_NAME" => "$(TARGET_NAME)", "SWIFT_EMIT_LOC_STRINGS" => "NO", "TARGETED_DEVICE_FAMILY" => "1", "TEST_HOST" => "$(BUILT_PRODUCTS_DIR)/#{APP_TARGET}.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/#{APP_TARGET}")
+  end
+
+  def render_project
+    <<~PBX
+      // !$*UTF8*$!
+      {
+          archiveVersion = 1;
+          classes = {
+          };
+          objectVersion = 56;
+          objects = {
+      #{render_objects}
+          };
+          rootObject = #{id("project")};
+      }
+    PBX
+  end
+
+  def render_objects
+    @objects.map { |object_id, attrs| "\t\t#{object_id} = #{render_value(attrs, "\t\t")};" }.join("\n")
+  end
+
+  def render_value(value, indent)
+    case value
+    when Ref then value.value
+    when Hash
+      body = value.map { |key, child| "#{indent}\t#{render_key(key)} = #{render_value(child, "#{indent}\t")};" }.join("\n")
+      "{\n#{body}\n#{indent}}"
+    when Array
+      body = value.map { |child| "#{indent}\t#{render_value(child, "#{indent}\t")}," }.join("\n")
+      "(\n#{body}\n#{indent})"
+    when Integer then value.to_s
+    else quote(value)
+    end
+  end
+
+  def render_key(key)
+    key.is_a?(Ref) ? key.value : key.to_s
+  end
+
+  def quote(value)
+    string = value.to_s.gsub("\\", "\\\\").gsub('"', '\\"')
+    "\"#{string}\""
+  end
+
+  def workspace
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <Workspace version="1.0">
+         <FileRef location="self:"></FileRef>
+      </Workspace>
+    XML
+  end
+
+  def app_source
+    <<~SWIFT
+      import PreviewGallery
+      import SnapshotPreferences
+      import SwiftUI
+
+      @main
+      struct BinarySmokeApp: App {
+        var body: some Scene {
+          WindowGroup {
+            NavigationView {
+              VStack(spacing: 16) {
+                SmokeView()
+                NavigationLink("Open Gallery") { PreviewGallery() }
+              }
+            }
+          }
+        }
+      }
+
+      struct SmokeView: View {
+        var body: some View {
+          Text("Binary smoke")
+            .padding()
+            .snapshotDiffThreshold(0.2)
+            .snapshotTags(["integration": "binary"])
+            .snapshotAdditionalContext(["binary_smoke": true])
+            .snapshotRenderingMode(.coreAnimation)
+        }
+      }
+
+      struct SmokeView_Previews: PreviewProvider {
+        static var previews: some View {
+          SmokeView().previewDisplayName("Binary Smoke Preview")
+        }
+      }
+    SWIFT
+  end
+
+  def test_source
+    <<~SWIFT
+      import Darwin
+      import SnapshottingTests
+      import XCTest
+
+      final class BinarySmokeSnapshotTest: SnapshotTest {
+        override class func snapshotPreviews() -> [String]? { ["BinarySmokeApp.SmokeView_Previews"] }
+        override class func snapshotPreviewModules() -> [String]? { ["BinarySmokeApp"] }
+      }
+
+      final class BinarySmokeDynamicLoadingTests: XCTestCase {
+        @MainActor
+        func testManuallyLinkedFrameworkDependenciesAreLoaded() {
+          let loaded = Set(Bundle.allFrameworks.map { $0.bundleURL.lastPathComponent })
+          for framework in ["PreviewGallery.framework", "PreviewsSupport.framework", "SnapshotPreferences.framework", "SnapshotPreviewsCore.framework", "SnapshotSharedModels.framework", "SnapshottingTests.framework"] {
+            XCTAssertTrue(loaded.contains(framework), "Expected \\(framework) to be loaded; loaded: \\(loaded.sorted())")
+          }
+          XCTAssertNotNil(dlopen("@rpath/SnapshottingTests.framework/SnapshottingTests", RTLD_NOW))
+          XCTAssertNotNil(dlopen("@rpath/PreviewGallery.framework/PreviewGallery", RTLD_NOW))
+          XCTAssertNotNil(dlopen("@rpath/SnapshotPreferences.framework/SnapshotPreferences", RTLD_NOW))
+        }
+      }
+    SWIFT
+  end
+
+  def scheme
+    app_ref = buildable_ref(id("app_target"), APP_TARGET, "#{APP_TARGET}.app")
+    test_ref = buildable_ref(id("test_target"), TEST_TARGET, "#{TEST_TARGET}.xctest")
+    <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <Scheme LastUpgradeVersion="1540" version="1.7">
+        <BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES"><BuildActionEntries><BuildActionEntry buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForArchiving="YES" buildForAnalyzing="YES">#{app_ref}</BuildActionEntry><BuildActionEntry buildForTesting="YES" buildForRunning="NO" buildForProfiling="NO" buildForArchiving="NO" buildForAnalyzing="YES">#{test_ref}</BuildActionEntry></BuildActionEntries></BuildAction>
+        <TestAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES"><Testables><TestableReference skipped="NO" parallelizable="NO">#{test_ref}</TestableReference></Testables><MacroExpansion>#{app_ref}</MacroExpansion></TestAction>
+        <LaunchAction buildConfiguration="Debug" selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" useCustomWorkingDirectory="NO" ignoresPersistentStateOnLaunch="NO" debugDocumentVersioning="YES" debugServiceExtension="internal" allowLocationSimulation="YES"><BuildableProductRunnable runnableDebuggingMode="0">#{app_ref}</BuildableProductRunnable></LaunchAction>
+        <ProfileAction buildConfiguration="Debug" shouldUseLaunchSchemeArgsEnv="YES" savedToolIdentifier="" useCustomWorkingDirectory="NO" debugDocumentVersioning="YES"><BuildableProductRunnable runnableDebuggingMode="0">#{app_ref}</BuildableProductRunnable></ProfileAction>
+        <AnalyzeAction buildConfiguration="Debug"/><ArchiveAction buildConfiguration="Debug" revealArchiveInOrganizer="YES"/>
+      </Scheme>
+    XML
+  end
+
+  def buildable_ref(target_id, target_name, buildable_name)
+    "<BuildableReference BuildableIdentifier=\"primary\" BlueprintIdentifier=\"#{target_id}\" BuildableName=\"#{buildable_name}\" BlueprintName=\"#{target_name}\" ReferencedContainer=\"container:#{PROJECT_NAME}.xcodeproj\"/>"
+  end
+end
+
+class SmokeRunner
+  def run
+    ensure_artifacts!
+    project = SmokeProject.new
+    project.write
+    run_xcodebuild(project.project_path)
+    validate_export!
+    puts "Binary integration iOS smoke passed."
+  end
+
+  private
+
+  def ensure_artifacts!
+    missing = FRAMEWORK_PATHS.reject { |_name, path| File.directory?(path) }
+    abort "Missing XCFramework artifacts: #{missing.map { |name, path| "#{name} at #{path}" }.join(", ")}. Run bash build.sh first." unless missing.empty?
+  end
+
+  def run_xcodebuild(project_path)
+    FileUtils.rm_rf([EXPORT_DIR, RESULT_BUNDLE_PATH])
+    FileUtils.mkdir_p(EXPORT_DIR)
+    command = ["xcodebuild", "test", "-project", project_path, "-scheme", PROJECT_NAME, "-destination", "id=#{ios_simulator_udid}", "-derivedDataPath", DERIVED_DATA_DIR, "-resultBundlePath", RESULT_BUNDLE_PATH, "CODE_SIGNING_ALLOWED=NO"]
+    env = { "TEST_RUNNER_SNAPSHOTS_EXPORT_DIR" => EXPORT_DIR, "TEST_RUNNER_EMERGE_DISABLE_FIX_TIME" => "1" }
+    puts [env.map { |key, value| "#{key}=#{value.shellescape}" }, command.map(&:shellescape)].flatten.join(" ")
+    abort "Binary integration iOS smoke xcodebuild failed." unless system(env, *command)
+  end
+
+  def ios_simulator_udid
+    stdout, status = Open3.capture2("xcrun", "simctl", "list", "devices", "available", "--json")
+    abort "Failed to list iOS simulators with xcrun simctl." unless status.success?
+
+    devices = JSON.parse(stdout).fetch("devices").select { |runtime, _| runtime.include?("iOS") }.values.flatten
+    candidates = devices.select { |device| device["isAvailable"] && device.fetch("name", "").start_with?("iPhone") }
+    selected = candidates.find { |device| device["state"] == "Booted" } || candidates.find { |device| device["name"].include?("15") } || candidates.first
+    abort "No available iPhone simulator found for binary integration smoke." unless selected
+
+    selected.fetch("udid")
+  end
+
+  def validate_export!
+    pngs = Dir.glob(File.join(EXPORT_DIR, "**", "*.png"))
+    jsons = Dir.glob(File.join(EXPORT_DIR, "**", "*.json"))
+    abort "Expected exported snapshot PNGs in #{EXPORT_DIR}, found none." if pngs.empty?
+    abort "Expected exported snapshot JSON sidecars in #{EXPORT_DIR}, found none." if jsons.empty?
+
+    sidecars = jsons.map { |path| [path, JSON.parse(File.read(path))] }
+    path, sidecar = sidecars.find { |_path, data| data["display_name"] == "Binary Smoke Preview" || data.dig("context", "preview", "display_name") == "Binary Smoke Preview" }
+    abort "Expected a Binary Smoke Preview sidecar in #{jsons.join(", ")}." unless sidecar
+    abort "Expected exported sidecar tags to include integration=binary in #{path}." unless sidecar.fetch("tags", {})["integration"] == "binary"
+    abort "Expected exported sidecar context to include binary_smoke=true in #{path}." unless sidecar.fetch("context", {})["binary_smoke"] == true
+  end
+end
+
+SmokeRunner.new.run

--- a/scripts/validate_xcframework_distribution.rb
+++ b/scripts/validate_xcframework_distribution.rb
@@ -1,0 +1,288 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "find"
+require "set"
+require_relative "xcframework_distribution"
+
+module XCFrameworkDistribution
+  class Validator
+    def initialize
+      @errors = []
+    end
+
+    def run
+      validate_previews_support_slices
+      FRAMEWORKS.each { |framework| validate_framework(framework) }
+      finish
+    end
+
+    private
+
+    def validate_previews_support_slices
+      validate_required_slices(XCFrameworkDistribution.distributed_xcframework_path("PreviewsSupport"), "PreviewsSupport")
+    end
+
+    def validate_framework(framework)
+      xcframework_path = XCFrameworkDistribution.distributed_xcframework_path(framework.name)
+      unless File.directory?(xcframework_path)
+        error "Missing #{xcframework_path}"
+        return
+      end
+
+      validate_required_slices(xcframework_path, framework.name)
+      XCFrameworkDistribution.available_libraries(xcframework_path).each do |library|
+        validate_library(framework, xcframework_path, library)
+      end
+    end
+
+    def validate_required_slices(xcframework_path, name)
+      unless File.directory?(xcframework_path)
+        error "Missing #{xcframework_path}"
+        return
+      end
+
+      identifiers = XCFrameworkDistribution.available_libraries(xcframework_path).map { |entry| entry.fetch("LibraryIdentifier") }
+      missing = XCFrameworkDistribution.required_platform_missing_identifiers(identifiers)
+      return if missing.empty?
+
+      formatted = missing.join(", ")
+      error "#{name}.xcframework missing required slices: #{formatted}"
+    end
+
+    def validate_library(framework, xcframework_path, library)
+      identifier = library.fetch("LibraryIdentifier")
+      library_path = library.fetch("LibraryPath")
+      framework_dir = File.join(xcframework_path, identifier, library_path)
+      binary_path = binary_path_for(framework, xcframework_path, identifier, library_path, library["BinaryPath"])
+
+      unless File.file?(binary_path)
+        error "#{framework.name} #{identifier} missing binary at #{binary_path}"
+        return
+      end
+
+      validate_nested_frameworks(framework, identifier, framework_dir)
+      validate_macos_module_placement(framework, identifier, library, framework_dir)
+      validate_swift_interfaces(framework, identifier, framework_dir)
+      validate_dynamic_loads(framework, identifier, binary_path)
+    end
+
+    def binary_path_for(framework, xcframework_path, identifier, library_path, binary_path)
+      return File.join(xcframework_path, identifier, binary_path) if binary_path && !binary_path.empty?
+
+      framework_dir = File.join(xcframework_path, identifier, library_path)
+      executable_path = if File.directory?(File.join(framework_dir, "Versions/A"))
+                          File.join(framework_dir, "Versions/A", framework.name)
+                        else
+                          File.join(framework_dir, framework.name)
+                        end
+      executable_path
+    end
+
+    def validate_nested_frameworks(framework, identifier, framework_dir)
+      return unless File.directory?(framework_dir)
+
+      root = File.expand_path(framework_dir)
+      Find.find(framework_dir) do |path|
+        next unless path.end_with?(".framework")
+
+        expanded = File.expand_path(path)
+        next if expanded == root
+
+        error "#{framework.name} #{identifier} contains nested framework #{path}"
+        Find.prune
+      end
+    end
+
+    def validate_macos_module_placement(framework, identifier, library, framework_dir)
+      return unless framework.requires_swift_module
+      return unless library.fetch("SupportedPlatform") == "macos" && !library.key?("SupportedPlatformVariant")
+
+      versioned_modules = File.join(framework_dir, "Versions/A/Modules/#{framework.name}.swiftmodule")
+      root_modules = File.join(framework_dir, "Modules")
+      error "#{framework.name} #{identifier} missing macOS versioned Swift module at #{versioned_modules}" unless File.directory?(versioned_modules)
+      error "#{framework.name} #{identifier} Modules should symlink to Versions/Current/Modules" unless File.symlink?(root_modules)
+    end
+
+    def validate_swift_interfaces(framework, identifier, framework_dir)
+      return unless framework.requires_swift_module
+
+      module_dir = swift_module_dir(framework, framework_dir)
+      unless module_dir && File.directory?(module_dir)
+        error "#{framework.name} #{identifier} missing Swift module directory"
+        return
+      end
+
+      interfaces = Dir.glob(File.join(module_dir, "*.swiftinterface"))
+      if interfaces.empty?
+        error "#{framework.name} #{identifier} missing .swiftinterface files in #{module_dir}"
+        return
+      end
+
+      interfaces.each do |interface_path|
+        imports = swift_interface_imports(interface_path)
+        unexpected_project = (imports & PROJECT_FRAMEWORK_NAMES.to_set) - framework.allowed_interface_imports.to_set - [framework.name].to_set
+        unless unexpected_project.empty?
+          error "#{framework.name} #{identifier} interface #{interface_path} imports unexpected project modules: #{unexpected_project.to_a.sort.join(", ")}"
+        end
+
+        unexpected_modules = imports & disallowed_interface_modules
+        unless unexpected_modules.empty?
+          error "#{framework.name} #{identifier} interface #{interface_path} imports non-public implementation modules: #{unexpected_modules.to_a.sort.join(", ")}"
+        end
+
+        forbidden_references = forbidden_interface_references(interface_path)
+        next if forbidden_references.empty?
+
+        error "#{framework.name} #{identifier} interface #{interface_path} contains forbidden references: #{forbidden_references.to_a.sort.join(", ")}"
+      end
+    end
+
+    def swift_module_dir(framework, framework_dir)
+      candidates = [
+        File.join(framework_dir, "Versions/A/Modules/#{framework.name}.swiftmodule"),
+        File.join(framework_dir, "Modules/#{framework.name}.swiftmodule")
+      ]
+      candidates.find { |candidate| File.directory?(candidate) }
+    end
+
+    def swift_interface_imports(interface_path)
+      imports = Set.new
+      File.foreach(interface_path) do |line|
+        module_name = swift_interface_import_module(line)
+        imports << module_name unless module_name.nil?
+      end
+      imports
+    end
+
+    def swift_interface_import_module(line)
+      tokens = line.strip.split
+      tokens.shift while tokens.first&.start_with?("@")
+      tokens.shift while %w[public internal package private fileprivate].include?(tokens.first)
+      return nil unless tokens.shift == "import"
+
+      tokens.shift if %w[class struct enum protocol func var let typealias].include?(tokens.first)
+      tokens.first&.split(".")&.first
+    end
+
+    def disallowed_interface_modules
+      private_modules = FRAMEWORKS.flat_map(&:private_source_targets)
+      (private_modules + EXTERNAL_PACKAGES.keys).to_set
+    end
+
+    def forbidden_interface_references(interface_path)
+      references = Set.new
+      content = File.read(interface_path)
+      references << "NSInvocation" if content.include?("NSInvocation")
+      references
+    end
+
+    def validate_dynamic_loads(framework, identifier, binary_path)
+      binary_architectures(binary_path).each do |architecture|
+        loads = dynamic_loads(binary_path, architecture, framework.name, identifier)
+        next if loads.nil?
+
+        validation_identifier = architecture.nil? ? identifier : "#{identifier} #{architecture}"
+        validate_project_dynamic_loads(framework, validation_identifier, loads)
+        validate_unexpected_dynamic_loads(framework, validation_identifier, loads)
+      end
+    end
+
+    def binary_architectures(binary_path)
+      stdout, status = command_output(["lipo", "-archs", binary_path])
+      return [nil] unless status.success?
+
+      architectures = stdout.split
+      architectures.empty? ? [nil] : architectures
+    end
+
+    def dynamic_loads(binary_path, architecture, framework_name, identifier)
+      command = architecture.nil? ? ["otool", "-L", binary_path] : ["otool", "-arch", architecture, "-L", binary_path]
+      stdout, status = command_output(command)
+      unless status.success?
+        error "#{command.join(" ")} failed for #{framework_name} #{identifier}"
+        return nil
+      end
+
+      stdout.lines.each_with_object([]) do |line, loads|
+        candidate = line.strip.split(/\s+/).first
+        next if candidate.nil? || candidate.empty? || candidate.end_with?(":")
+
+        loads << candidate
+      end
+    end
+
+    def validate_project_dynamic_loads(framework, identifier, loads)
+      actual_project_loads = loads.each_with_object(Set.new) do |load, project_loads|
+        canonical = canonical_project_load(load)
+        project_loads << canonical unless canonical.nil?
+      end
+      expected_project_loads = framework.expected_project_loads.to_set
+
+      missing = expected_project_loads - actual_project_loads
+      unexpected = actual_project_loads - expected_project_loads - [XCFrameworkDistribution.project_load(framework.name)].to_set
+      error "#{framework.name} #{identifier} missing project dynamic loads: #{missing.to_a.sort.join(", ")}" unless missing.empty?
+      error "#{framework.name} #{identifier} has unexpected project dynamic loads: #{unexpected.to_a.sort.join(", ")}" unless unexpected.empty?
+    end
+
+    def canonical_project_load(load)
+      name = framework_name_from_load(load)
+      return nil unless PROJECT_FRAMEWORK_NAMES.include?(name)
+
+      XCFrameworkDistribution.project_load(name)
+    end
+
+    def framework_name_from_load(load)
+      match = load.match(%r{\A@rpath/([^/]+)\.framework/(?:Versions/[^/]+/)?\1\z})
+      match && match[1]
+    end
+
+    def validate_unexpected_dynamic_loads(framework, identifier, loads)
+      loads.each do |load|
+        name = framework_name_from_load(load)
+        if UNEXPECTED_THIRD_PARTY_FRAMEWORKS.include?(name)
+          error "#{framework.name} #{identifier} has unexpected third-party dynamic load #{load}"
+          next
+        end
+
+        next unless load.start_with?("@rpath/")
+        next if load.start_with?("@rpath/libswift")
+        next if ALLOWED_APPLE_RPATH_DYLIBS.include?(File.basename(load))
+
+        if name.nil?
+          error "#{framework.name} #{identifier} has unexpected non-system dynamic load #{load}"
+          next
+        end
+
+        next if PROJECT_FRAMEWORK_NAMES.include?(name)
+        next if ALLOWED_APPLE_RPATH_FRAMEWORKS.include?(name)
+
+        error "#{framework.name} #{identifier} has unexpected non-system dynamic load #{load}"
+      end
+    end
+
+    def command_output(command)
+      output = IO.popen(command, &:read)
+      [output, $?]
+    end
+
+    def error(message)
+      @errors << message
+    end
+
+    def finish
+      if @errors.empty?
+        puts "XCFramework distribution validation passed."
+        $stdout.flush
+        exit!(0)
+      else
+        warn "XCFramework distribution validation failed:"
+        @errors.each { |message| warn "- #{message}" }
+        $stderr.flush
+        exit!(1)
+      end
+    end
+  end
+end
+
+XCFrameworkDistribution::Validator.new.run

--- a/scripts/xcframework_distribution.rb
+++ b/scripts/xcframework_distribution.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "json"
+require "pathname"
+
+module XCFrameworkDistribution
+  ROOT = File.expand_path("..", __dir__)
+  DISTRIBUTION_DIR = File.join(ROOT, "XCFrameworks")
+  PREVIEWS_SUPPORT_XCFRAMEWORK = File.join(ROOT, "PreviewsSupport", "PreviewsSupport.xcframework")
+
+  def self.distributed_xcframework_path(name)
+    File.join(DISTRIBUTION_DIR, "#{name}.xcframework")
+  end
+
+  Platform = Struct.new(:sdk, :destination, :identifier, :display_identifier, keyword_init: true) do
+    def matches?(library_identifier)
+      identifier.is_a?(Regexp) ? library_identifier.match?(identifier) : library_identifier == identifier
+    end
+
+    def missing_identifier
+      display_identifier || identifier
+    end
+  end
+  Framework = Struct.new(
+    :name,
+    :category,
+    :source_targets,
+    :private_source_targets,
+    :binary_dependencies,
+    :compile_time_binary_dependencies,
+    :external_packages,
+    :target_dependencies,
+    :public_header_targets,
+    :linker_retained_dependencies,
+    :expected_project_loads,
+    :allowed_interface_imports,
+    :requires_swift_module,
+    keyword_init: true
+  ) do
+    def all_source_targets
+      source_targets + private_source_targets
+    end
+
+    def all_binary_dependencies
+      (binary_dependencies + compile_time_binary_dependencies).uniq
+    end
+  end
+
+  PLATFORMS = [
+    Platform.new(sdk: "iphonesimulator", destination: "generic/platform=iOS Simulator", identifier: "ios-arm64_x86_64-simulator"),
+    Platform.new(sdk: "iphoneos", destination: "generic/platform=iOS", identifier: "ios-arm64"),
+    Platform.new(sdk: "macosx", destination: "generic/platform=macOS", identifier: "macos-arm64_x86_64"),
+    Platform.new(sdk: "watchsimulator", destination: "generic/platform=watchOS Simulator", identifier: "watchos-arm64_x86_64-simulator"),
+    Platform.new(sdk: "watchos", destination: "generic/platform=watchOS", identifier: /^watchos-arm64_arm64_32/, display_identifier: "watchos-arm64_arm64_32*")
+  ].freeze
+
+  PROJECT_FRAMEWORK_NAMES = [
+    "SnapshotSharedModels",
+    "SnapshotPreviewsCore",
+    "SnapshotPreferences",
+    "PreviewGallery",
+    "SnapshottingTests",
+    "Snapshotting",
+    "PreviewsSupport"
+  ].freeze
+
+  EXTERNAL_PACKAGES = {
+    "FlyingFox" => ".package(url: \"https://github.com/swhitty/FlyingFox.git\", exact: \"0.16.0\")",
+    "SimpleDebugger" => ".package(url: \"https://github.com/EmergeTools/SimpleDebugger.git\", exact: \"1.0.0\")"
+  }.freeze
+
+  UNEXPECTED_THIRD_PARTY_FRAMEWORKS = ["FlyingFox", "SimpleDebugger"].freeze
+  ALLOWED_APPLE_RPATH_FRAMEWORKS = ["XCTest"].freeze
+  ALLOWED_APPLE_RPATH_DYLIBS = ["libXCTestSwiftSupport.dylib"].freeze
+
+  def self.project_load(name)
+    "@rpath/#{name}.framework/#{name}"
+  end
+
+  FRAMEWORKS = [
+    Framework.new(
+      name: "SnapshotSharedModels",
+      category: "required_support",
+      source_targets: ["SnapshotSharedModels"],
+      private_source_targets: [],
+      binary_dependencies: [],
+      compile_time_binary_dependencies: [],
+      external_packages: [],
+      target_dependencies: { "SnapshotSharedModels" => [] },
+      public_header_targets: [],
+      linker_retained_dependencies: [],
+      expected_project_loads: [],
+      allowed_interface_imports: [],
+      requires_swift_module: true
+    ),
+    Framework.new(
+      name: "SnapshotPreviewsCore",
+      category: "required_support",
+      source_targets: ["SnapshotPreviewsCore"],
+      private_source_targets: [],
+      binary_dependencies: ["SnapshotSharedModels", "PreviewsSupport"],
+      compile_time_binary_dependencies: [],
+      external_packages: [],
+      target_dependencies: { "SnapshotPreviewsCore" => ["SnapshotSharedModels", "PreviewsSupport"] },
+      public_header_targets: [],
+      linker_retained_dependencies: ["SnapshotSharedModels", "PreviewsSupport"],
+      expected_project_loads: [project_load("SnapshotSharedModels"), project_load("PreviewsSupport")],
+      allowed_interface_imports: ["SnapshotSharedModels", "PreviewsSupport"],
+      requires_swift_module: true
+    ),
+    Framework.new(
+      name: "SnapshotPreferences",
+      category: "user_facing_entry_point",
+      source_targets: ["SnapshotPreferences"],
+      private_source_targets: [],
+      binary_dependencies: ["SnapshotSharedModels"],
+      compile_time_binary_dependencies: [],
+      external_packages: [],
+      target_dependencies: { "SnapshotPreferences" => ["SnapshotSharedModels"] },
+      public_header_targets: [],
+      linker_retained_dependencies: ["SnapshotSharedModels"],
+      expected_project_loads: [project_load("SnapshotSharedModels")],
+      allowed_interface_imports: ["SnapshotSharedModels"],
+      requires_swift_module: true
+    ),
+    Framework.new(
+      name: "PreviewGallery",
+      category: "user_facing_entry_point",
+      source_targets: ["PreviewGallery"],
+      private_source_targets: [],
+      binary_dependencies: ["SnapshotPreviewsCore", "SnapshotPreferences"],
+      compile_time_binary_dependencies: ["SnapshotSharedModels", "PreviewsSupport"],
+      external_packages: [],
+      target_dependencies: { "PreviewGallery" => ["SnapshotPreviewsCore", "SnapshotPreferences", "SnapshotSharedModels", "PreviewsSupport"] },
+      public_header_targets: [],
+      linker_retained_dependencies: ["SnapshotPreviewsCore", "SnapshotPreferences", "SnapshotSharedModels", "PreviewsSupport"],
+      expected_project_loads: [project_load("SnapshotPreviewsCore"), project_load("SnapshotPreferences"), project_load("SnapshotSharedModels"), project_load("PreviewsSupport")],
+      allowed_interface_imports: ["SnapshotPreviewsCore", "SnapshotPreferences"],
+      requires_swift_module: true
+    ),
+    Framework.new(
+      name: "SnapshottingTests",
+      category: "user_facing_entry_point",
+      source_targets: ["SnapshottingTests"],
+      private_source_targets: ["SnapshottingTestsObjc"],
+      binary_dependencies: ["SnapshotPreviewsCore", "SnapshotSharedModels"],
+      compile_time_binary_dependencies: ["PreviewsSupport"],
+      external_packages: ["SimpleDebugger"],
+      target_dependencies: {
+        "SnapshottingTests" => ["SnapshotPreviewsCore", "SnapshottingTestsObjc", "SnapshotSharedModels", "PreviewsSupport"],
+        "SnapshottingTestsObjc" => [".product(name: \"SimpleDebugger\", package: \"SimpleDebugger\", condition: .when(platforms: [.iOS, .macOS, .macCatalyst]))"]
+      },
+      public_header_targets: ["SnapshottingTestsObjc"],
+      linker_retained_dependencies: ["SnapshotPreviewsCore", "SnapshotSharedModels", "PreviewsSupport"],
+      expected_project_loads: [project_load("SnapshotPreviewsCore"), project_load("SnapshotSharedModels"), project_load("PreviewsSupport")],
+      allowed_interface_imports: ["SnapshotSharedModels", "SnapshotPreviewsCore"],
+      requires_swift_module: true
+    ),
+    Framework.new(
+      name: "Snapshotting",
+      category: "compatibility_runtime",
+      source_targets: ["Snapshotting"],
+      private_source_targets: ["SnapshottingSwift"],
+      binary_dependencies: ["SnapshotPreviewsCore"],
+      compile_time_binary_dependencies: ["SnapshotSharedModels", "PreviewsSupport"],
+      external_packages: ["FlyingFox"],
+      target_dependencies: {
+        "Snapshotting" => ["SnapshottingSwift", "SnapshotPreviewsCore", "SnapshotSharedModels", "PreviewsSupport"],
+        "SnapshottingSwift" => ["SnapshotPreviewsCore", "SnapshotSharedModels", "PreviewsSupport", ".product(name: \"FlyingFox\", package: \"FlyingFox\")"]
+      },
+      public_header_targets: ["Snapshotting"],
+      linker_retained_dependencies: ["SnapshotPreviewsCore", "SnapshotSharedModels", "PreviewsSupport"],
+      expected_project_loads: [project_load("SnapshotPreviewsCore"), project_load("SnapshotSharedModels"), project_load("PreviewsSupport")],
+      allowed_interface_imports: [],
+      requires_swift_module: false
+    )
+  ].freeze
+
+  FRAMEWORK_BY_NAME = FRAMEWORKS.to_h { |framework| [framework.name, framework] }.freeze
+
+  def self.available_libraries(xcframework_path)
+    info_path = File.join(xcframework_path, "Info.plist")
+    stdout = IO.popen(["plutil", "-convert", "json", "-o", "-", info_path], &:read)
+    raise "Failed to read #{info_path}" unless $?.success?
+
+    JSON.parse(stdout).fetch("AvailableLibraries")
+  end
+
+  def self.required_platform_missing_identifiers(identifiers)
+    PLATFORMS.each_with_object([]) do |platform, missing|
+      matched = identifiers.any? { |identifier| platform.matches?(identifier) }
+      missing << platform.missing_identifier unless matched
+    end
+  end
+end


### PR DESCRIPTION
Adds XCFramework binary distribution support for SnapshotPreviews while keeping the standard Swift Package integration source-first.

The binary distribution produces a documented framework set under `XCFrameworks/`, validates that those frameworks form the expected dynamic dependency graph, and includes a separate example project that consumes the generated frameworks manually.

**Swift Package vs binary distribution**

`Package.swift` keeps the normal Swift Package linkage model separate from binary distribution. Regular library products remain explicit static products for the source-package path, matching the existing package behavior and Xcode 15 CI expectations. `Snapshotting` remains explicitly dynamic because it is the inserted/runtime dylib product.

Binary artifact generation is handled separately by `build.sh` and the Ruby distribution tooling. That tooling creates temporary SwiftPM distribution packages and forces dynamic framework output only for the XCFramework build path.

**Vended artifact layout**

Generated binary artifacts are written to `XCFrameworks/`:

- `SnapshotSharedModels.xcframework`
- `SnapshotPreviewsCore.xcframework`
- `SnapshotPreferences.xcframework`
- `PreviewGallery.xcframework`
- `SnapshottingTests.xcframework`
- `Snapshotting.xcframework`
- `PreviewsSupport.xcframework`

`PreviewsSupport` remains checked in at `PreviewsSupport/PreviewsSupport.xcframework` for SwiftPM usage. The distribution build copies it into `XCFrameworks/` so binary consumers and GitHub release assets have one artifact folder.

**Dynamic dependency model**

Manual XCFramework integration does not get SwiftPM's dependency resolution automatically, so binary consumers must link the documented framework closure for the product they use.

The build validates that shared SnapshotPreviews dependencies remain real dynamic framework dependencies instead of being embedded repeatedly into parent frameworks. This avoids loading duplicate copies of shared modules when consumers link multiple SnapshotPreviews frameworks in the same process.

**Binary example project**

`Examples/DemoApp` is the normal local Swift Package example.

`Examples/DemoApp-XCFrameworks` is the manual binary integration example. It shares source files from `../DemoApp/...`, links against `../../XCFrameworks/*.xcframework`, and includes a small wrapper script:

```bash
cd Examples/DemoApp-XCFrameworks
./generate-xcframeworks.sh
open DemoApp-XCFrameworks.xcodeproj
```

Shared demo source that depends on optional external packages uses `canImport`, so the SPM example can keep accessibility snapshot rendering while the XCFramework example builds without the external accessibility package.

**Manual integration matrix**

For an app target using snapshot preferences:

- `SnapshotPreferences.xcframework`
- `SnapshotSharedModels.xcframework`

For an app target using `PreviewGallery`:

- `PreviewGallery.xcframework`
- `SnapshotPreviewsCore.xcframework`
- `SnapshotPreferences.xcframework`
- `SnapshotSharedModels.xcframework`
- `PreviewsSupport.xcframework`

For an XCTest target using `SnapshottingTests`:

- `SnapshottingTests.xcframework`
- `SnapshotPreviewsCore.xcframework`
- `SnapshotSharedModels.xcframework`
- `PreviewsSupport.xcframework`

For the inserted-dylib/accessibility runtime flow, also include:

- `Snapshotting.xcframework`

**Validation**

The distribution validation checks expected artifacts, supported slices, public Swift interface imports, macOS Swift module placement, missing nested frameworks, expected dynamic load commands, and `PreviewsSupport` packaging.

The iOS binary smoke test builds a temporary binary-only app/test project and verifies app-target imports, test-target imports, manual framework loading, and snapshot PNG/JSON export.

Refs EME-1168