### PR TITLE
build: Add XCFramework binary distribution support

### DIFF
--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -11,8 +11,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Xcode select
         run: sudo xcode-select -s '/Applications/Xcode_15.4.app/Contents/Developer'
-      - name: Build xcframework
-        run: sh build.sh
+      - name: Build xcframeworks
+        run: bash build.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Xcode select
         run: sudo xcode-select -s '/Applications/Xcode_15.4.app/Contents/Developer'
       - name: Build TestApp
-        run: cd Examples && xcodebuild build -scheme DemoApp -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -project DemoApp/DemoApp.xcodeproj
+        run: cd Examples && xcodebuild build -scheme DemoApp -destination 'generic/platform=iOS Simulator' -project DemoApp/DemoApp.xcodeproj
       - name: Build Snapshotting
         run: xcodebuild build -scheme Snapshotting -sdk iphonesimulator -destination 'generic/platform=iOS Simulator'
       - name: Build SnapshottingTests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,6 @@ jobs:
         run: bash build.sh
       - name: Zip xcframeworks
         run: |
-          rm -f *.xcframework.zip
           for framework_path in XCFrameworks/*.xcframework
           do
             framework="$(basename "$framework_path")"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,25 +11,24 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Xcode select
         run: sudo xcode-select -s '/Applications/Xcode_15.4.app/Contents/Developer'
-      - name: Build xcframework
-        run: sh build.sh
-      - name: Zip SnapshottingTests xcframework
-        run: zip -r SnapshottingTests.xcframework.zip SnapshottingTests.xcframework
-      - name: Zip PreviewGallery xcframework
-        run: zip -r PreviewGallery.xcframework.zip PreviewGallery.xcframework
-      - name: Zip preivews support
-        run: (cd PreviewsSupport && zip -r PreviewsSupport.xcframework.zip PreviewsSupport.xcframework)
+      - name: Build xcframeworks
+        run: bash build.sh
+      - name: Zip xcframeworks
+        run: |
+          rm -f *.xcframework.zip
+          for framework_path in XCFrameworks/*.xcframework
+          do
+            framework="$(basename "$framework_path")"
+            (cd XCFrameworks && zip -r "../$framework.zip" "$framework")
+          done
       - name: Upload Artifact
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: |
-            PreviewGallery.xcframework.zip
-            SnapshottingTests.xcframework.zip
-            PreviewsSupport/PreviewsSupport.xcframework.zip
+          files: "*.xcframework.zip"
           body:
             Release ${{ github.ref }}
             Automated release created by GitHub Actions.

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .DS_Store
+/build/
+/Package.resolved
+/XCFrameworks/
 /.build
 /Packages
 xcuserdata/

--- a/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/project.pbxproj
+++ b/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/project.pbxproj
@@ -7,6 +7,54 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8B2B491A2FD01D8B003221F3 /* SnapshottingTests.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */; };
+		8B2B491B2FD01D8B003221F3 /* SnapshottingTests.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B491C2FD01D94003221F3 /* PreviewGallery.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49122FD01D81003221F3 /* PreviewGallery.xcframework */; };
+		8B2B491D2FD01D94003221F3 /* PreviewGallery.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49122FD01D81003221F3 /* PreviewGallery.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B491F2FD01D9F003221F3 /* SnapshottingTests.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */; };
+		8B2B49202FD01D9F003221F3 /* SnapshottingTests.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49222FD01DAA003221F3 /* SnapshottingTests.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */; };
+		8B2B49232FD01DAA003221F3 /* SnapshottingTests.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49252FD01DB3003221F3 /* SnapshotPreferences.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */; };
+		8B2B49282FD01DBD003221F3 /* PreviewGallery.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49122FD01D81003221F3 /* PreviewGallery.xcframework */; };
+		8B2B49292FD01DBD003221F3 /* PreviewGallery.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49122FD01D81003221F3 /* PreviewGallery.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B492A2FD01DC1003221F3 /* SnapshotPreferences.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */; };
+		8B2B492B2FD01DC1003221F3 /* SnapshotPreferences.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B492C2FD01E1C003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; };
+		8B2B492D2FD01E1C003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B492E2FD01E23003221F3 /* SnapshotSharedModels.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; };
+		8B2B492F2FD01E23003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49312FD01E8B003221F3 /* PreviewsSupport.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; };
+		8B2B49322FD01EC1003221F3 /* SnapshotSharedModels.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; };
+		8B2B49342FD01EDD003221F3 /* PreviewsSupport.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; };
+		8B2B49352FD01EDD003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49362FD01EDD003221F3 /* SnapshotPreferences.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */; };
+		8B2B49372FD01EDD003221F3 /* SnapshotPreferences.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49382FD01EDD003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; };
+		8B2B49392FD01EDD003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B493A2FD01EDD003221F3 /* SnapshotSharedModels.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; };
+		8B2B493B2FD01EDD003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B493C2FD01F1B003221F3 /* PreviewsSupport.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; };
+		8B2B493D2FD01F1B003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B493E2FD01F1B003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; };
+		8B2B493F2FD01F1B003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49402FD01F1B003221F3 /* SnapshotSharedModels.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; };
+		8B2B49412FD01F1B003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49422FD01F30003221F3 /* PreviewsSupport.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; };
+		8B2B49432FD01F30003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49442FD01F30003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; };
+		8B2B49452FD01F30003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49462FD01F30003221F3 /* SnapshotSharedModels.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; };
+		8B2B49472FD01F30003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B49482FD01F3A003221F3 /* PreviewsSupport.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; };
+		8B2B49492FD01F3A003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B494A2FD01F3A003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; };
+		8B2B494B2FD01F3A003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B494C2FD01F3A003221F3 /* SnapshotSharedModels.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; };
+		8B2B494D2FD01F3A003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B494E2FD09E01003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8B2B494F2FD0A000003221F3 /* Snapshotting.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49162FD01D81003221F3 /* Snapshotting.xcframework */; };
+		8B2B49502FD0A000003221F3 /* Snapshotting.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B2B49162FD01D81003221F3 /* Snapshotting.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FA0B20F12A7DA20200EC91D3 /* AnyViewPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0B20F02A7DA20200EC91D3 /* AnyViewPreview.swift */; };
 		FA0B20FA2A7DCB0100EC91D3 /* ArrayBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0B20F82A7DCB0100EC91D3 /* ArrayBuilder.swift */; };
 		FA0B20FB2A7DCB0100EC91D3 /* PreviewVariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0B20F92A7DCB0100EC91D3 /* PreviewVariants.swift */; };
@@ -28,31 +76,22 @@
 		FA1671FB2A53E03800A42DB0 /* MessageRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1671FA2A53E03800A42DB0 /* MessageRow.swift */; };
 		FA1671FD2A53E11E00A42DB0 /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1671FC2A53E11E00A42DB0 /* MessageView.swift */; };
 		FA1671FF2A53E1AF00A42DB0 /* ConversationMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1671FE2A53E1AF00A42DB0 /* ConversationMessageView.swift */; };
-		FA170AD32A8B3BA400D1D53D /* PreviewGallery in Frameworks */ = {isa = PBXBuildFile; productRef = FA170AD22A8B3BA400D1D53D /* PreviewGallery */; };
 		FA1E452E2ADF3C3D002C85DB /* UIViewPreviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1E452D2ADF3C3D002C85DB /* UIViewPreviews.swift */; };
 		FA309EC32C38D71C00C85FF4 /* DemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA309EC22C38D71C00C85FF4 /* DemoApp.swift */; };
 		FA309EC52C38D71C00C85FF4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA309EC42C38D71C00C85FF4 /* ContentView.swift */; };
 		FA309EC72C38D71D00C85FF4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FA309EC62C38D71D00C85FF4 /* Assets.xcassets */; };
 		FA309ECA2C38D71D00C85FF4 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FA309EC92C38D71D00C85FF4 /* Preview Assets.xcassets */; };
 		FA309ECD2C38D71D00C85FF4 /* Demo Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = FA309EC02C38D71C00C85FF4 /* Demo Watch App.app */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		FA309EE22C38D7A900C85FF4 /* Snapshotting in Frameworks */ = {isa = PBXBuildFile; productRef = FA309EE12C38D7A900C85FF4 /* Snapshotting */; };
-		FA309EE32C38D7A900C85FF4 /* Snapshotting in Embed Frameworks */ = {isa = PBXBuildFile; productRef = FA309EE12C38D7A900C85FF4 /* Snapshotting */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		FA309EE62C38D7AC00C85FF4 /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = FA309EE52C38D7AC00C85FF4 /* SnapshottingTests */; };
 		FA309EE72C38EB9B00C85FF4 /* DemoWatchAccessibilityPreviewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA309ED82C38D77C00C85FF4 /* DemoWatchAccessibilityPreviewTest.swift */; };
-		FA309EFE2C3EF68A00C85FF4 /* PreviewGallery in Frameworks */ = {isa = PBXBuildFile; productRef = FA309EFD2C3EF68A00C85FF4 /* PreviewGallery */; };
 		FA40515D2A95B587007A66D4 /* EmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA40515C2A95B587007A66D4 /* EmptyView.swift */; };
 		FA5E82972A96448A008DE3F0 /* StateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5E82962A96448A008DE3F0 /* StateView.swift */; };
-		FA7EFE132B9235D100EF534F /* SnapshotPreferences in Frameworks */ = {isa = PBXBuildFile; productRef = FA7EFE122B9235D100EF534F /* SnapshotPreferences */; };
-		FA8E2F9E2E8D797000B7B9EB /* AccessibilitySnapshotCore in Frameworks */ = {isa = PBXBuildFile; productRef = FA8E2F9D2E8D797000B7B9EB /* AccessibilitySnapshotCore */; };
 		FA8F8B7E2C66C4C4007CEA33 /* DemoAppPreviewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8F8B7D2C66C4C4007CEA33 /* DemoAppPreviewTest.swift */; };
-		FA8F8B852C66C4CA007CEA33 /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = FA8F8B842C66C4CA007CEA33 /* SnapshottingTests */; };
 		FA9C8E442A56959300DC4574 /* RatingPreviews.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9C8E432A56959300DC4574 /* RatingPreviews.swift */; };
 		FAA4F4CF2B271D9C00127B63 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA4F4CE2B271D9C00127B63 /* Color.swift */; };
 		FABCCD932AC39081008F4D3A /* EMGTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABCCD922AC39081008F4D3A /* EMGTestHandler.swift */; };
 		FAC912372C894B6E00459191 /* OSVersionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC912362C894B6E00459191 /* OSVersionView.swift */; };
 		FACA23792A55FBEE0080545A /* DemoModule.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA1671D72A5399F700A42DB0 /* DemoModule.framework */; };
 		FACBADA32C67B8D60012D600 /* DemoWatchPreviewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACBADA22C67B8D60012D600 /* DemoWatchPreviewTest.swift */; };
-		FACBADAA2C67B8ED0012D600 /* SnapshottingTests in Frameworks */ = {isa = PBXBuildFile; productRef = FACBADA92C67B8ED0012D600 /* SnapshottingTests */; };
 		FACBADAC2C67B9A50012D600 /* DemoWatchSnapshotTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FACBADAB2C67B9A50012D600 /* DemoWatchSnapshotTest.swift */; };
 		FAD0107B2AA29ABA007D1AF6 /* TextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD0107A2AA29ABA007D1AF6 /* TextView.swift */; };
 		FAD52BF62A7B5EEA001F1832 /* ExpandingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD52BF12A7B5EEA001F1832 /* ExpandingView.swift */; };
@@ -102,13 +141,61 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		8B2B491E2FD01D94003221F3 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				8B2B49372FD01EDD003221F3 /* SnapshotPreferences.xcframework in Embed Frameworks */,
+				8B2B49352FD01EDD003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */,
+				8B2B49392FD01EDD003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */,
+				8B2B491D2FD01D94003221F3 /* PreviewGallery.xcframework in Embed Frameworks */,
+				8B2B493B2FD01EDD003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B2B49212FD01D9F003221F3 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				8B2B49472FD01F30003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */,
+				8B2B49452FD01F30003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */,
+				8B2B49432FD01F30003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */,
+				8B2B49202FD01D9F003221F3 /* SnapshottingTests.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8B2B49242FD01DAA003221F3 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				8B2B494D2FD01F3A003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */,
+				8B2B494B2FD01F3A003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */,
+				8B2B49492FD01F3A003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */,
+				8B2B49232FD01DAA003221F3 /* SnapshottingTests.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FA1671E22A5399F700A42DB0 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				8B2B492B2FD01DC1003221F3 /* SnapshotPreferences.xcframework in Embed Frameworks */,
 				FA1671DE2A5399F700A42DB0 /* DemoModule.framework in Embed Frameworks */,
+				8B2B494E2FD09E01003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */,
+				8B2B492D2FD01E1C003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */,
+				8B2B49292FD01DBD003221F3 /* PreviewGallery.xcframework in Embed Frameworks */,
+				8B2B492F2FD01E23003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -130,7 +217,11 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				FA309EE32C38D7A900C85FF4 /* Snapshotting in Embed Frameworks */,
+				8B2B49502FD0A000003221F3 /* Snapshotting.xcframework in Embed Frameworks */,
+				8B2B491B2FD01D8B003221F3 /* SnapshottingTests.xcframework in Embed Frameworks */,
+				8B2B493D2FD01F1B003221F3 /* PreviewsSupport.xcframework in Embed Frameworks */,
+				8B2B493F2FD01F1B003221F3 /* SnapshotPreviewsCore.xcframework in Embed Frameworks */,
+				8B2B49412FD01F1B003221F3 /* SnapshotSharedModels.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -138,6 +229,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		8B2B49122FD01D81003221F3 /* PreviewGallery.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PreviewGallery.xcframework; path = ../../XCFrameworks/PreviewGallery.xcframework; sourceTree = "<group>"; };
+		8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SnapshotPreferences.xcframework; path = ../../XCFrameworks/SnapshotPreferences.xcframework; sourceTree = "<group>"; };
+		8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SnapshotPreviewsCore.xcframework; path = ../../XCFrameworks/SnapshotPreviewsCore.xcframework; sourceTree = "<group>"; };
+		8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SnapshotSharedModels.xcframework; path = ../../XCFrameworks/SnapshotSharedModels.xcframework; sourceTree = "<group>"; };
+		8B2B49162FD01D81003221F3 /* Snapshotting.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Snapshotting.xcframework; path = ../../XCFrameworks/Snapshotting.xcframework; sourceTree = "<group>"; };
+		8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SnapshottingTests.xcframework; path = ../../XCFrameworks/SnapshottingTests.xcframework; sourceTree = "<group>"; };
+		8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = PreviewsSupport.xcframework; path = ../../XCFrameworks/PreviewsSupport.xcframework; sourceTree = "<group>"; };
 		C39F81522C6ABB7A004C7D57 /* DemoAppTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = DemoAppTests.xctestplan; sourceTree = "<group>"; };
 		FA0B20F02A7DA20200EC91D3 /* AnyViewPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyViewPreview.swift; sourceTree = "<group>"; };
 		FA0B20F82A7DCB0100EC91D3 /* ArrayBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayBuilder.swift; sourceTree = "<group>"; };
@@ -190,7 +288,6 @@
 		FAD52BF42A7B5EEA001F1832 /* RideShareButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RideShareButton.swift; sourceTree = "<group>"; };
 		FAD52BF52A7B5EEA001F1832 /* RideOptionsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RideOptionsView.swift; sourceTree = "<group>"; };
 		FADB112B2C67A17500985C48 /* DemoAppSnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppSnapshotTest.swift; sourceTree = "<group>"; };
-		FAF1BA622A54934200AEBE1B /* .. */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = ..; path = ../../..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -198,8 +295,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA170AD32A8B3BA400D1D53D /* PreviewGallery in Frameworks */,
+				8B2B492A2FD01DC1003221F3 /* SnapshotPreferences.xcframework in Frameworks */,
+				8B2B49282FD01DBD003221F3 /* PreviewGallery.xcframework in Frameworks */,
+				8B2B492C2FD01E1C003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */,
 				FACA23792A55FBEE0080545A /* DemoModule.framework in Frameworks */,
+				8B2B49312FD01E8B003221F3 /* PreviewsSupport.xcframework in Frameworks */,
+				8B2B492E2FD01E23003221F3 /* SnapshotSharedModels.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -207,7 +308,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA7EFE132B9235D100EF534F /* SnapshotPreferences in Frameworks */,
+				8B2B49322FD01EC1003221F3 /* SnapshotSharedModels.xcframework in Frameworks */,
+				8B2B49252FD01DB3003221F3 /* SnapshotPreferences.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -215,7 +317,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA309EFE2C3EF68A00C85FF4 /* PreviewGallery in Frameworks */,
+				8B2B49362FD01EDD003221F3 /* SnapshotPreferences.xcframework in Frameworks */,
+				8B2B49342FD01EDD003221F3 /* PreviewsSupport.xcframework in Frameworks */,
+				8B2B49382FD01EDD003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */,
+				8B2B491C2FD01D94003221F3 /* PreviewGallery.xcframework in Frameworks */,
+				8B2B493A2FD01EDD003221F3 /* SnapshotSharedModels.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -223,8 +329,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA309EE62C38D7AC00C85FF4 /* SnapshottingTests in Frameworks */,
-				FA309EE22C38D7A900C85FF4 /* Snapshotting in Frameworks */,
+				8B2B494F2FD0A000003221F3 /* Snapshotting.xcframework in Frameworks */,
+				8B2B491A2FD01D8B003221F3 /* SnapshottingTests.xcframework in Frameworks */,
+				8B2B493C2FD01F1B003221F3 /* PreviewsSupport.xcframework in Frameworks */,
+				8B2B493E2FD01F1B003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */,
+				8B2B49402FD01F1B003221F3 /* SnapshotSharedModels.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -232,8 +341,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FA8E2F9E2E8D797000B7B9EB /* AccessibilitySnapshotCore in Frameworks */,
-				FA8F8B852C66C4CA007CEA33 /* SnapshottingTests in Frameworks */,
+				8B2B49462FD01F30003221F3 /* SnapshotSharedModels.xcframework in Frameworks */,
+				8B2B49442FD01F30003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */,
+				8B2B49422FD01F30003221F3 /* PreviewsSupport.xcframework in Frameworks */,
+				8B2B491F2FD01D9F003221F3 /* SnapshottingTests.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -241,7 +352,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FACBADAA2C67B8ED0012D600 /* SnapshottingTests in Frameworks */,
+				8B2B494C2FD01F3A003221F3 /* SnapshotSharedModels.xcframework in Frameworks */,
+				8B2B494A2FD01F3A003221F3 /* SnapshotPreviewsCore.xcframework in Frameworks */,
+				8B2B49482FD01F3A003221F3 /* PreviewsSupport.xcframework in Frameworks */,
+				8B2B49222FD01DAA003221F3 /* SnapshottingTests.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -253,12 +367,12 @@
 			children = (
 				C39F81522C6ABB7A004C7D57 /* DemoAppTests.xctestplan */,
 				FA44246E2AAA5B27005BFCD9 /* DemoApp.xctestplan */,
-				FA1671C12A5367A800A42DB0 /* DemoApp */,
-				FA1671D82A5399F700A42DB0 /* DemoModule */,
-				FA309EC12C38D71C00C85FF4 /* Demo Watch App */,
-				FA309ED72C38D77C00C85FF4 /* DemoWatchTests */,
-				FA8F8B7C2C66C4C4007CEA33 /* DemoAppTests */,
-				FACBADA12C67B8D60012D600 /* Demo Watch AppTests */,
+				FA1671C12A5367A800A42DB0 /* ../DemoApp/DemoApp */,
+				FA1671D82A5399F700A42DB0 /* ../DemoApp/DemoModule */,
+				FA309EC12C38D71C00C85FF4 /* ../DemoApp/Demo Watch App */,
+				FA309ED72C38D77C00C85FF4 /* ../DemoApp/DemoWatchTests */,
+				FA8F8B7C2C66C4C4007CEA33 /* ../DemoApp/DemoAppTests */,
+				FACBADA12C67B8D60012D600 /* ../DemoApp/Demo Watch AppTests */,
 				FA1671C02A5367A800A42DB0 /* Products */,
 				FA6E72BD2A54944800448463 /* Frameworks */,
 			);
@@ -277,10 +391,9 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		FA1671C12A5367A800A42DB0 /* DemoApp */ = {
+		FA1671C12A5367A800A42DB0 /* ../DemoApp/DemoApp */ = {
 			isa = PBXGroup;
 			children = (
-				FAF1BA622A54934200AEBE1B /* .. */,
 				FA1671C22A5367A800A42DB0 /* DemoAppApp.swift */,
 				FABCCD922AC39081008F4D3A /* EMGTestHandler.swift */,
 				FA1671C42A5367A800A42DB0 /* ContentView.swift */,
@@ -289,7 +402,7 @@
 				FA1671C82A5367A800A42DB0 /* DemoApp.entitlements */,
 				FA1671C92A5367A800A42DB0 /* Preview Content */,
 			);
-			path = DemoApp;
+			path = ../DemoApp/DemoApp;
 			sourceTree = "<group>";
 		};
 		FA1671C92A5367A800A42DB0 /* Preview Content */ = {
@@ -300,7 +413,7 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
-		FA1671D82A5399F700A42DB0 /* DemoModule */ = {
+		FA1671D82A5399F700A42DB0 /* ../DemoApp/DemoModule */ = {
 			isa = PBXGroup;
 			children = (
 				FA1671D92A5399F700A42DB0 /* DemoModule.h */,
@@ -319,10 +432,10 @@
 				FA1671FE2A53E1AF00A42DB0 /* ConversationMessageView.swift */,
 				FA13B8EE2B3E8B3300F58836 /* DateView.swift */,
 			);
-			path = DemoModule;
+			path = ../DemoApp/DemoModule;
 			sourceTree = "<group>";
 		};
-		FA309EC12C38D71C00C85FF4 /* Demo Watch App */ = {
+		FA309EC12C38D71C00C85FF4 /* ../DemoApp/Demo Watch App */ = {
 			isa = PBXGroup;
 			children = (
 				FA309EC22C38D71C00C85FF4 /* DemoApp.swift */,
@@ -330,7 +443,7 @@
 				FA309EC62C38D71D00C85FF4 /* Assets.xcassets */,
 				FA309EC82C38D71D00C85FF4 /* Preview Content */,
 			);
-			path = "Demo Watch App";
+			path = "../DemoApp/Demo Watch App";
 			sourceTree = "<group>";
 		};
 		FA309EC82C38D71D00C85FF4 /* Preview Content */ = {
@@ -341,38 +454,45 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
-		FA309ED72C38D77C00C85FF4 /* DemoWatchTests */ = {
+		FA309ED72C38D77C00C85FF4 /* ../DemoApp/DemoWatchTests */ = {
 			isa = PBXGroup;
 			children = (
 				FA309ED82C38D77C00C85FF4 /* DemoWatchAccessibilityPreviewTest.swift */,
 			);
-			path = DemoWatchTests;
+			path = ../DemoApp/DemoWatchTests;
 			sourceTree = "<group>";
 		};
 		FA6E72BD2A54944800448463 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				8B2B49122FD01D81003221F3 /* PreviewGallery.xcframework */,
+				8B2B49132FD01D81003221F3 /* SnapshotPreferences.xcframework */,
+				8B2B49142FD01D81003221F3 /* SnapshotPreviewsCore.xcframework */,
+				8B2B49152FD01D81003221F3 /* SnapshotSharedModels.xcframework */,
+				8B2B49162FD01D81003221F3 /* Snapshotting.xcframework */,
+				8B2B49172FD01D81003221F3 /* SnapshottingTests.xcframework */,
+				8B2B49302FD01E8B003221F3 /* PreviewsSupport.xcframework */,
 				FACA23752A55FB970080545A /* XCTest.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		FA8F8B7C2C66C4C4007CEA33 /* DemoAppTests */ = {
+		FA8F8B7C2C66C4C4007CEA33 /* ../DemoApp/DemoAppTests */ = {
 			isa = PBXGroup;
 			children = (
 				FA8F8B7D2C66C4C4007CEA33 /* DemoAppPreviewTest.swift */,
 				FADB112B2C67A17500985C48 /* DemoAppSnapshotTest.swift */,
 			);
-			path = DemoAppTests;
+			path = ../DemoApp/DemoAppTests;
 			sourceTree = "<group>";
 		};
-		FACBADA12C67B8D60012D600 /* Demo Watch AppTests */ = {
+		FACBADA12C67B8D60012D600 /* ../DemoApp/Demo Watch AppTests */ = {
 			isa = PBXGroup;
 			children = (
 				FACBADA22C67B8D60012D600 /* DemoWatchPreviewTest.swift */,
 				FACBADAB2C67B9A50012D600 /* DemoWatchSnapshotTest.swift */,
 			);
-			path = "Demo Watch AppTests";
+			path = "../DemoApp/Demo Watch AppTests";
 			sourceTree = "<group>";
 		};
 		FAD52BF02A7B5EBB001F1832 /* TestViews */ = {
@@ -427,7 +547,6 @@
 			);
 			name = DemoApp;
 			packageProductDependencies = (
-				FA170AD22A8B3BA400D1D53D /* PreviewGallery */,
 			);
 			productName = DemoApp;
 			productReference = FA1671BF2A5367A800A42DB0 /* DemoApp.app */;
@@ -448,7 +567,6 @@
 			);
 			name = DemoModule;
 			packageProductDependencies = (
-				FA7EFE122B9235D100EF534F /* SnapshotPreferences */,
 			);
 			productName = DemoModule;
 			productReference = FA1671D72A5399F700A42DB0 /* DemoModule.framework */;
@@ -461,6 +579,7 @@
 				FA309EBC2C38D71C00C85FF4 /* Sources */,
 				FA309EBD2C38D71C00C85FF4 /* Frameworks */,
 				FA309EBE2C38D71C00C85FF4 /* Resources */,
+				8B2B491E2FD01D94003221F3 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -468,7 +587,6 @@
 			);
 			name = "Demo Watch App";
 			packageProductDependencies = (
-				FA309EFD2C3EF68A00C85FF4 /* PreviewGallery */,
 			);
 			productName = "Demo Watch App";
 			productReference = FA309EC02C38D71C00C85FF4 /* Demo Watch App.app */;
@@ -490,8 +608,6 @@
 			);
 			name = DemoWatchTests;
 			packageProductDependencies = (
-				FA309EE12C38D7A900C85FF4 /* Snapshotting */,
-				FA309EE52C38D7AC00C85FF4 /* SnapshottingTests */,
 			);
 			productName = Demo;
 			productReference = FA309ED62C38D77C00C85FF4 /* DemoWatchTests.xctest */;
@@ -504,6 +620,7 @@
 				FA8F8B772C66C4C4007CEA33 /* Sources */,
 				FA8F8B782C66C4C4007CEA33 /* Frameworks */,
 				FA8F8B792C66C4C4007CEA33 /* Resources */,
+				8B2B49212FD01D9F003221F3 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -512,8 +629,6 @@
 			);
 			name = DemoAppTests;
 			packageProductDependencies = (
-				FA8F8B842C66C4CA007CEA33 /* SnapshottingTests */,
-				FA8E2F9D2E8D797000B7B9EB /* AccessibilitySnapshotCore */,
 			);
 			productName = DemoAppTests;
 			productReference = FA8F8B7B2C66C4C4007CEA33 /* DemoAppTests.xctest */;
@@ -526,6 +641,7 @@
 				FACBAD9C2C67B8D60012D600 /* Sources */,
 				FACBAD9D2C67B8D60012D600 /* Frameworks */,
 				FACBAD9E2C67B8D60012D600 /* Resources */,
+				8B2B49242FD01DAA003221F3 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -534,7 +650,6 @@
 			);
 			name = "Demo Watch AppTests";
 			packageProductDependencies = (
-				FACBADA92C67B8ED0012D600 /* SnapshottingTests */,
 			);
 			productName = "Demo Watch AppTests";
 			productReference = FACBADA02C67B8D60012D600 /* Demo Watch AppTests.xctest */;
@@ -574,7 +689,7 @@
 					};
 				};
 			};
-			buildConfigurationList = FA1671BA2A5367A800A42DB0 /* Build configuration list for PBXProject "DemoApp" */;
+			buildConfigurationList = FA1671BA2A5367A800A42DB0 /* Build configuration list for PBXProject "DemoApp-XCFrameworks" */;
 			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -584,7 +699,6 @@
 			);
 			mainGroup = FA1671B62A5367A800A42DB0;
 			packageReferences = (
-				FA8E2F9C2E8D797000B7B9EB /* XCRemoteSwiftPackageReference "AccessibilitySnapshot" */,
 			);
 			productRefGroup = FA1671C02A5367A800A42DB0 /* Products */;
 			projectDirPath = "";
@@ -886,11 +1000,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = DemoApp/DemoApp.entitlements;
+				CODE_SIGN_ENTITLEMENTS = ../DemoApp/DemoApp/DemoApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"DemoApp/Preview Content\"";
-				DEVELOPMENT_TEAM = 62J2XHNK9T;
+				DEVELOPMENT_ASSET_PATHS = "\"../DemoApp/DemoApp/Preview Content\"";
+				DEVELOPMENT_TEAM = BR6WD3M6ZD;
 				ENABLE_DEBUG_DYLIB = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_PREVIEWS = YES;
@@ -914,12 +1028,12 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_DOCUMENTATION_COMPILER = YES;
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
-				SUPPORTS_MACCATALYST = YES;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -929,11 +1043,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_ENTITLEMENTS = DemoApp/DemoApp.entitlements;
+				CODE_SIGN_ENTITLEMENTS = ../DemoApp/DemoApp/DemoApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"DemoApp/Preview Content\"";
-				DEVELOPMENT_TEAM = 62J2XHNK9T;
+				DEVELOPMENT_ASSET_PATHS = "\"../DemoApp/DemoApp/Preview Content\"";
+				DEVELOPMENT_TEAM = BR6WD3M6ZD;
 				ENABLE_DEBUG_DYLIB = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_PREVIEWS = YES;
@@ -957,12 +1071,12 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_DOCUMENTATION_COMPILER = YES;
 				SDKROOT = auto;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
-				SUPPORTS_MACCATALYST = YES;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -973,7 +1087,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = J9H72XH8P9;
+				DEVELOPMENT_TEAM = BR6WD3M6ZD;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -998,13 +1112,12 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1017,7 +1130,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = J9H72XH8P9;
+				DEVELOPMENT_TEAM = BR6WD3M6ZD;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1042,12 +1155,11 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2,7";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1060,13 +1172,13 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"Demo Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = 62J2XHNK9T;
+				DEVELOPMENT_ASSET_PATHS = "\"../DemoApp/Demo Watch App/Preview Content\"";
+				DEVELOPMENT_TEAM = BR6WD3M6ZD;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Demo;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIDeviceFamily = 4;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKApplication = YES;
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.emerge.PreviewsDemoApp;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1093,13 +1205,13 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"Demo Watch App/Preview Content\"";
-				DEVELOPMENT_TEAM = 62J2XHNK9T;
+				DEVELOPMENT_ASSET_PATHS = "\"../DemoApp/Demo Watch App/Preview Content\"";
+				DEVELOPMENT_TEAM = BR6WD3M6ZD;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = Demo;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UIDeviceFamily = 4;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_WKApplication = YES;
 				INFOPLIST_KEY_WKCompanionAppBundleIdentifier = com.emerge.PreviewsDemoApp;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1173,7 +1285,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1195,7 +1309,9 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1248,7 +1364,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		FA1671BA2A5367A800A42DB0 /* Build configuration list for PBXProject "DemoApp" */ = {
+		FA1671BA2A5367A800A42DB0 /* Build configuration list for PBXProject "DemoApp-XCFrameworks" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				FA1671CC2A5367A800A42DB0 /* Debug */,
@@ -1312,53 +1428,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		FA8E2F9C2E8D797000B7B9EB /* XCRemoteSwiftPackageReference "AccessibilitySnapshot" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/EmergeTools/AccessibilitySnapshot.git";
-			requirement = {
-				kind = exactVersion;
-				version = 1.0.2;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		FA170AD22A8B3BA400D1D53D /* PreviewGallery */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = PreviewGallery;
-		};
-		FA309EE12C38D7A900C85FF4 /* Snapshotting */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Snapshotting;
-		};
-		FA309EE52C38D7AC00C85FF4 /* SnapshottingTests */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SnapshottingTests;
-		};
-		FA309EFD2C3EF68A00C85FF4 /* PreviewGallery */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = PreviewGallery;
-		};
-		FA7EFE122B9235D100EF534F /* SnapshotPreferences */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SnapshotPreferences;
-		};
-		FA8E2F9D2E8D797000B7B9EB /* AccessibilitySnapshotCore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FA8E2F9C2E8D797000B7B9EB /* XCRemoteSwiftPackageReference "AccessibilitySnapshot" */;
-			productName = AccessibilitySnapshotCore;
-		};
-		FA8F8B842C66C4CA007CEA33 /* SnapshottingTests */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SnapshottingTests;
-		};
-		FACBADA92C67B8ED0012D600 /* SnapshottingTests */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = SnapshottingTests;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = FA1671B72A5367A800A42DB0 /* Project object */;
 }

--- a/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/xcshareddata/xcschemes/Demo Watch App.xcscheme
+++ b/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/xcshareddata/xcschemes/Demo Watch App.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA309EBF2C38D71C00C85FF4"
+               BuildableName = "Demo Watch App.app"
+               BlueprintName = "Demo Watch App"
+               ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FACBAD9F2C67B8D60012D600"
+               BuildableName = "Demo Watch AppTests.xctest"
+               BlueprintName = "Demo Watch AppTests"
+               ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA309EBF2C38D71C00C85FF4"
+            BuildableName = "Demo Watch App.app"
+            BlueprintName = "Demo Watch App"
+            ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA309EBF2C38D71C00C85FF4"
+            BuildableName = "Demo Watch App.app"
+            BlueprintName = "Demo Watch App"
+            ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
+++ b/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA1671BE2A5367A800A42DB0"
+               BuildableName = "DemoApp.app"
+               BlueprintName = "DemoApp"
+               ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:DemoApp.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA1671BE2A5367A800A42DB0"
+            BuildableName = "DemoApp.app"
+            BlueprintName = "DemoApp"
+            ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA1671BE2A5367A800A42DB0"
+            BuildableName = "DemoApp.app"
+            BlueprintName = "DemoApp"
+            ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/xcshareddata/xcschemes/DemoAppTests.xcscheme
+++ b/Examples/DemoApp-XCFrameworks/DemoApp-XCFrameworks.xcodeproj/xcshareddata/xcschemes/DemoAppTests.xcscheme
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:DemoAppTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA8F8B7A2C66C4C4007CEA33"
+               BuildableName = "DemoAppTests.xctest"
+               BlueprintName = "DemoAppTests"
+               ReferencedContainer = "container:DemoApp-XCFrameworks.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/DemoApp-XCFrameworks/DemoApp.xctestplan
+++ b/Examples/DemoApp-XCFrameworks/DemoApp.xctestplan
@@ -1,0 +1,20 @@
+{
+  "configurations": [
+    {
+      "id": "FF846110-BFA2-419E-BF99-A9FC438920E2",
+      "name": "Configuration 1",
+      "options": {}
+    }
+  ],
+  "defaultOptions": {},
+  "testTargets": [
+    {
+      "target": {
+        "containerPath": "container:DemoApp-XCFrameworks.xcodeproj",
+        "identifier": "FA8F8B7A2C66C4C4007CEA33",
+        "name": "DemoAppTests"
+      }
+    }
+  ],
+  "version": 1
+}

--- a/Examples/DemoApp-XCFrameworks/DemoAppTests.xctestplan
+++ b/Examples/DemoApp-XCFrameworks/DemoAppTests.xctestplan
@@ -1,0 +1,20 @@
+{
+  "configurations": [
+    {
+      "id": "B1D580A7-404D-4E1D-80D8-0E56CDD58281",
+      "name": "Test Scheme Action",
+      "options": {}
+    }
+  ],
+  "defaultOptions": {},
+  "testTargets": [
+    {
+      "target": {
+        "containerPath": "container:DemoApp-XCFrameworks.xcodeproj",
+        "identifier": "FA8F8B7A2C66C4C4007CEA33",
+        "name": "DemoAppTests"
+      }
+    }
+  ],
+  "version": 1
+}

--- a/Examples/DemoApp-XCFrameworks/README.md
+++ b/Examples/DemoApp-XCFrameworks/README.md
@@ -1,0 +1,13 @@
+# DemoApp XCFrameworks Example
+
+This example uses the same demo sources as `Examples/DemoApp`, but links against locally generated XCFrameworks instead of the Swift package.
+
+Generate the frameworks before opening or building the project. This requires Xcode and delegates to the repository-level XCFramework build script.
+
+```bash
+cd Examples/DemoApp-XCFrameworks
+./generate-xcframeworks.sh
+open DemoApp-XCFrameworks.xcodeproj
+```
+
+The project expects the generated artifacts in the repository root `XCFrameworks/` folder, for example `../../XCFrameworks/SnapshottingTests.xcframework` and `../../XCFrameworks/PreviewsSupport.xcframework`.

--- a/Examples/DemoApp-XCFrameworks/generate-xcframeworks.sh
+++ b/Examples/DemoApp-XCFrameworks/generate-xcframeworks.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+./build.sh

--- a/Examples/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/Demo Watch App.xcscheme
+++ b/Examples/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/Demo Watch App.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FA309EBF2C38D71C00C85FF4"
+               BuildableName = "Demo Watch App.app"
+               BlueprintName = "Demo Watch App"
+               ReferencedContainer = "container:DemoApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FACBAD9F2C67B8D60012D600"
+               BuildableName = "Demo Watch AppTests.xctest"
+               BlueprintName = "Demo Watch AppTests"
+               ReferencedContainer = "container:DemoApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA309EBF2C38D71C00C85FF4"
+            BuildableName = "Demo Watch App.app"
+            BlueprintName = "Demo Watch App"
+            ReferencedContainer = "container:DemoApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FA309EBF2C38D71C00C85FF4"
+            BuildableName = "Demo Watch App.app"
+            BlueprintName = "Demo Watch App"
+            ReferencedContainer = "container:DemoApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/DemoApp/DemoAppTests/DemoAppSnapshotTest.swift
+++ b/Examples/DemoApp/DemoAppTests/DemoAppSnapshotTest.swift
@@ -9,8 +9,10 @@ import Foundation
 #if canImport(UIKit)
 import UIKit
 #endif
-import SnapshottingTests
+#if canImport(AccessibilitySnapshotCore)
 import AccessibilitySnapshotCore
+#endif
+import SnapshottingTests
 
 class DemoAppSnapshotTest: SnapshotTest {
   override class func snapshotPreviews() -> [String]? {
@@ -28,8 +30,8 @@ class DemoAppSnapshotTest: SnapshotTest {
   override class func excludedSnapshotPreviewModules() -> [String]? {
     return nil
   }
-  
-  #if canImport(UIKit) && !os(watchOS) && !os(visionOS) && !os(tvOS)
+
+  #if canImport(UIKit) && canImport(AccessibilitySnapshotCore) && !os(watchOS) && !os(visionOS) && !os(tvOS)
   override open class func setupA11y() -> ((UIViewController, UIWindow, PreviewLayout) -> UIView)? {
     return { (controller: UIViewController, window: UIWindow, layout: PreviewLayout) in
       let containerVC = controller.parent
@@ -45,7 +47,7 @@ class DemoAppSnapshotTest: SnapshotTest {
         viewRenderingMode: controller.view.bounds.size.requiresCoreAnimationSnapshot ? .renderLayerInContext : .drawHierarchyInRect,
         activationPointDisplayMode: .never,
         showUserInputLabels: true)
-    
+
       a11yView.center = window.center
       window.addSubview(a11yView)
 
@@ -57,8 +59,10 @@ class DemoAppSnapshotTest: SnapshotTest {
   #endif
 }
 
+#if canImport(UIKit)
 extension CGSize {
   var requiresCoreAnimationSnapshot: Bool {
     height >= UIScreen.main.bounds.size.height * 2
   }
 }
+#endif

--- a/Examples/DemoApp/DemoWatchTests/DemoWatchAccessibilityPreviewTest.swift
+++ b/Examples/DemoApp/DemoWatchTests/DemoWatchAccessibilityPreviewTest.swift
@@ -5,7 +5,6 @@
 //  Created by Noah Martin on 7/5/24.
 //
 
-import Snapshotting
 import SnapshottingTests
 import XCTest
 

--- a/Package.swift
+++ b/Package.swift
@@ -10,13 +10,11 @@ let package = Package(
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(
           name: "PreviewGallery",
-          type: .static, // Replace this to build dynamic
           targets: ["PreviewGallery"]),
         // Test library to import in your XCTest target.
         // This is the only library that depends on XCTest.framework
         .library(
           name: "SnapshottingTests",
-          type: .static, // Replace this to build dynamic
           targets: ["SnapshottingTests"]),
         // Link the main app to this target to use custom snapshot settings
         // This lib does not get inserted when running tests to avoid
@@ -28,6 +26,10 @@ let package = Package(
         .library(
           name: "SnapshotPreviewsCore",
           targets: ["SnapshotPreviewsCore"]),
+        // Shared models required by the binary framework distribution.
+        .library(
+          name: "SnapshotSharedModels",
+          targets: ["SnapshotSharedModels"]),
         // Dynamic library that your main app will have inserted to generate previews
         .library(
           name: "Snapshotting",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Generate snapshot images from your Xcode previews with zero test code, and export them to disk for upload to [Sentry Snapshots](https://docs.sentry.io/product/snapshots/) or any other visual diffing service. Works with SwiftUI and UIKit previews using `PreviewProvider` or `#Preview`, on all Apple platforms (iOS / macOS / watchOS / tvOS / visionOS).
 
-# Installation
+## Installation
 
 Add the package as a Swift Package Manager dependency using the repository URL:
 
@@ -19,7 +19,7 @@ https://github.com/EmergeTools/SnapshotPreviews
 
 Link your XCTest target to the `SnapshottingTests` product. If you also want to customize per-preview rendering (e.g. precision, layout) you can link `SnapshotPreferences` to your app target.
 
-# Generating Snapshots
+## Generating Snapshots
 
 Create a test class that inherits from `SnapshotTest`. There are no test functions to write — they're added at runtime, one per discovered preview:
 
@@ -44,7 +44,7 @@ By default each rendered preview is attached to the XCTest results bundle as a P
 
 ![Screenshot of Xcode test output](https://raw.githubusercontent.com/EmergeTools/SnapshotPreviews/master/images/testOutput.png)
 
-## Filtering by module
+### Filtering by module
 
 If your app links several frameworks, you can scope discovery to specific modules:
 
@@ -59,13 +59,13 @@ override class func excludedSnapshotPreviewModules() -> [String]? { ["LegacyModu
 > [!NOTE]
 > Preview macros (`#Preview("Display Name")`) produce snapshot names based on file path and display name, for example: `MyModule/MyFile.swift:Display Name`.
 
-# Uploading Snapshots to Sentry
+## Exporting snapshots for Sentry
 
 `SnapshotPreviews` is the recommended iOS feeder for [Sentry Snapshots](https://docs.sentry.io/product/snapshots/). The flow has two steps: `xcodebuild test` writes PNGs + JSON sidecars to a directory, then `sentry-cli build snapshots` uploads that directory.
 
 ![Sentry Snapshots visual diff UI](https://github.com/user-attachments/assets/3a9e5c84-7954-4e73-89a1-3e5a181b7c7c)
 
-## 1. Export the snapshots from your test run
+### 1. Export the snapshots from your test run
 
 Set `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR` on the test invocation. When set, `SnapshotTest` writes images directly to that directory instead of attaching them to the `.xcresult` bundle.
 
@@ -114,7 +114,7 @@ import SnapshotPreferences
 
 No Xcode code-coverage data (`.profraw` / `.profdata`) is written by the exporter — only the PNGs and sidecars. If you need code coverage from the same test run, enable it on the scheme as usual; coverage output goes to the `.xcresult` bundle independently.
 
-## 2. Upload to Sentry
+### 2. Upload to Sentry
 
 Choose one of the upload options below.
 
@@ -156,9 +156,9 @@ Use Sentry's Fastlane integration if your CI already uploads Apple artifacts thr
 
 See Sentry's [CI integration docs](https://docs.sentry.io/product/snapshots/integrating-into-ci/) for sharding across simulators and base/head SHA pinning.
 
-# Tips
+## Tips
 
-## Unique display names
+### Unique display names
 
 Give every preview a unique display name. This is what shows up in XCTest results and in the exported filenames / metadata:
 
@@ -176,11 +176,11 @@ struct MyView_Previews: PreviewProvider {
 
 Display names should be unique within each `PreviewProvider`, or within a file when using preview macros.
 
-## Snapshot best practices
+### Snapshot best practices
 
 Snapshot previews should be deterministic. Avoid live network calls, timers, animations that do not settle, locale-dependent data, and dates generated from the current clock. Prefer fixed fixtures and mocked dependencies so the same preview renders the same pixels in Xcode, local test runs, and CI.
 
-## Detecting the snapshot environment
+### Detecting the snapshot environment
 
 Set `SNAPSHOTS_RUNNING_FOR_PREVIEWS=1` in your unit test scheme to mirror the variable Xcode sets when rendering live previews. You can then disable preview-unfriendly behavior (logging, analytics, network calls) with a single check:
 
@@ -192,7 +192,7 @@ extension ProcessInfo {
 }
 ```
 
-## Snapshot modifiers
+### Snapshot modifiers
 
 Link the `SnapshotPreferences` product to your app target to customize individual previews before they are rendered by `SnapshotTest`.
 
@@ -205,7 +205,7 @@ Link the `SnapshotPreferences` product to your app target to customize individua
 | `.snapshotAdditionalContext(["fixture": "loaded"])` | You want extra sidecar metadata for debugging or filtering. | Adds fields to the JSON sidecar `context` object. Repeated context modifiers merge, and later duplicate keys win. Custom keys override generated context keys. |
 | `.snapshotDiffThreshold(0.05)` | A snapshot has small expected pixel differences. | Sets `diff_threshold` in the exported sidecar for this preview. `0.05` allows up to a 5% changed-pixel share before Sentry marks the image as changed. |
 
-## Variants
+### Variants
 
 > [!TIP]
 > `PreviewVariants` simplifies snapshot testing by ensuring a consistent set of variants and that every view has a name.
@@ -231,15 +231,50 @@ struct MyView_Previews: PreviewProvider {
 }
 ```
 
-# Additional Features
+## Additional Features
 
-## Preview rendering check (no PNGs)
+### Preview rendering check (no PNGs)
 
 If you only want to verify that every preview lays out without crashing — for example, to catch a missing `@EnvironmentObject` — inherit from `PreviewLayoutTest` instead of `SnapshotTest`. It runs the same discovery pipeline but skips the image render, so it's significantly faster. This gives you *preview coverage* (every preview was exercised); it does not produce Xcode code-coverage data.
 
-## Preview Gallery
+### Preview Gallery
 
 `PreviewGallery` is an interactive SwiftUI view that turns your previews into a browsable gallery of components — useful for internal builds where Xcode isn't available. Link your app to the `PreviewGallery` product and present it from wherever makes sense:
+
+> [!NOTE]
+> `PreviewGallery` discovers previews from runtime metadata in the built app. If no previews are present in that build, the gallery will open with no previews to display.
+
+#### Internal distribution builds
+
+`PreviewGallery` is designed for development and trusted internal distribution. If you want to include it in a TestFlight or other internal build, create a dedicated build configuration or archive scheme instead of changing your production Release configuration. The previews must both compile into that build and survive optimization:
+
+1. Link the app target to the `PreviewGallery` product.
+2. Configure Swift optimization so preview metadata is retained. Release configurations often use whole-module optimization, which can remove unreferenced preview declarations even when they compile successfully. For the internal gallery configuration, disable whole-module optimization or use a Debug-like compilation mode, then verify that the gallery shows the expected previews before distributing it.
+3. If your previews are wrapped in `#if DEBUG`, add a custom Swift compilation condition, such as `PREVIEW_GALLERY`, to the internal build configuration. In Xcode, set this under **Build Settings > Swift Compiler - Custom Flags > Active Compilation Conditions** (`SWIFT_ACTIVE_COMPILATION_CONDITIONS`). Then keep preview declarations compiled for Debug and that internal configuration:
+
+```swift
+#if DEBUG || PREVIEW_GALLERY
+#Preview {
+  MyView()
+}
+#endif
+```
+
+For `PreviewProvider` previews, wrap the provider type the same way:
+
+```swift
+#if DEBUG || PREVIEW_GALLERY
+struct MyView_Previews: PreviewProvider {
+  static var previews: some View {
+    MyView()
+  }
+}
+#endif
+```
+
+If your previews rely on assets, JSON fixtures, or other resources from a `Preview Content` folder, make sure those resources are included in the internal gallery build. Xcode Development Assets are intended for previews and Simulator development without increasing final app size, so they may not be present in builds you distribute.
+
+Only expose the gallery in trusted internal builds, and gate access appropriately, because previews can reveal unfinished UI, mock data, or internal states.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/EmergeTools/SnapshotPreviews/master/images/image1.png" />
@@ -263,7 +298,7 @@ struct InternalSettingsView: View {
 }
 ```
 
-## Accessibility audits
+### Accessibility audits
 
 Xcode [accessibility audits](https://developer.apple.com/documentation/xctest/xcuiapplication/4191487-performaccessibilityaudit) can run on every preview as part of a UI test. Inherit from `AccessibilityPreviewTest` and override the audit type / issue handler as needed:
 
@@ -293,11 +328,32 @@ See the demo app under `Examples/` for a full example.
   Previews are discovered in the test binary by parsing the `__swift5_proto` Mach-O section to find types that conform to `PreviewProvider` (and the related protocols generated by the `#Preview` macro). Background on how this works in the Swift runtime: [The Surprising Cost of Protocol Conformances in Swift](https://www.emergetools.com/blog/posts/SwiftProtocolConformance).
 </details>
 
-# Related Reading
+## Binary frameworks
+
+While Swift Package Manager is the recommended way to integrate SnapshotPreviews, every release also ships the frameworks as prebuilt XCFramework `.zip` assets:
+
+- `SnapshotPreferences.xcframework.zip` — user-facing SwiftUI preference modifiers.
+- `PreviewGallery.xcframework.zip` — user-facing preview gallery UI.
+- `SnapshottingTests.xcframework.zip` — user-facing XCTest snapshot and layout helpers.
+- `SnapshotSharedModels.xcframework.zip` — required support dependency shared by the public APIs.
+- `SnapshotPreviewsCore.xcframework.zip` — required support dependency for preview discovery and rendering.
+- `PreviewsSupport.xcframework.zip` — required binary support dependency for `SnapshotPreviewsCore`.
+- `Snapshotting.xcframework.zip` — compatibility/runtime artifact for inserted-dylib accessibility and UI-test workflows.
+
+Xcode does not infer transitive dependencies between manually added binary frameworks, so add the full dependency set for each target:
+
+- App target using per-preview rendering preferences: link and embed `SnapshotPreferences.xcframework` and `SnapshotSharedModels.xcframework`.
+- App target using the gallery UI: link and embed `PreviewGallery.xcframework`, `SnapshotPreviewsCore.xcframework`, `SnapshotPreferences.xcframework`, `SnapshotSharedModels.xcframework`, and `PreviewsSupport.xcframework`.
+- XCTest snapshot/layout target: link and embed `SnapshottingTests.xcframework`, `SnapshotPreviewsCore.xcframework`, `SnapshotSharedModels.xcframework`, and `PreviewsSupport.xcframework`.
+- Accessibility/UI-test target using the inserted-dylib flow: link and embed `SnapshottingTests.xcframework`, `Snapshotting.xcframework`, `SnapshotPreviewsCore.xcframework`, `SnapshotSharedModels.xcframework`, and `PreviewsSupport.xcframework`.
+
+You don't need to build anything to use the released artifacts above. You can build them locally from source using `bash build.sh` from the repository root. It requires Xcode and writes the frameworks to `XCFrameworks/`.
+
+## Related Reading
 
 - [How to use VariadicView, SwiftUI's Private View API](https://www.emergetools.com/blog/posts/how-to-use-variadic-view) — `VariadicView` is how multiple images are rendered for one `PreviewProvider`.
 - [The Surprising Cost of Protocol Conformances in Swift](https://www.emergetools.com/blog/posts/SwiftProtocolConformance) — how preview types are discovered in app binaries.
 
-# Star History
+## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=EmergeTools/SnapshotPreviews&type=Date)](https://star-history.com/#EmergeTools/SnapshotPreviews&Date)

--- a/XCFrameworkPackage.swift
+++ b/XCFrameworkPackage.swift
@@ -1,0 +1,66 @@
+// swift-tools-version: 5.7
+
+import Foundation
+import PackageDescription
+
+let product = ProcessInfo.processInfo.environment["SNAPSHOT_PREVIEWS_XCFRAMEWORK_PRODUCT"] ?? ""
+
+func selectedTargets() -> [Target] {
+  switch product {
+  case "SnapshotSharedModels":
+    return [
+      .target(name: "SnapshotSharedModels"),
+    ]
+  case "SnapshotPreviewsCore":
+    return [
+      .target(name: "SnapshotPreviewsCore", dependencies: ["PreviewsSupport", "SnapshotSharedModels"]),
+      .binaryTarget(name: "PreviewsSupport", path: "XCFrameworks/PreviewsSupport.xcframework"),
+      .binaryTarget(name: "SnapshotSharedModels", path: "XCFrameworks/SnapshotSharedModels.xcframework"),
+    ]
+  case "SnapshotPreferences":
+    return [
+      .target(name: "SnapshotPreferences", dependencies: ["SnapshotSharedModels"]),
+      .binaryTarget(name: "SnapshotSharedModels", path: "XCFrameworks/SnapshotSharedModels.xcframework"),
+    ]
+  case "PreviewGallery":
+    return [
+      .target(name: "PreviewGallery", dependencies: ["PreviewsSupport", "SnapshotSharedModels", "SnapshotPreviewsCore", "SnapshotPreferences"]),
+      .binaryTarget(name: "PreviewsSupport", path: "XCFrameworks/PreviewsSupport.xcframework"),
+      .binaryTarget(name: "SnapshotSharedModels", path: "XCFrameworks/SnapshotSharedModels.xcframework"),
+      .binaryTarget(name: "SnapshotPreviewsCore", path: "XCFrameworks/SnapshotPreviewsCore.xcframework"),
+      .binaryTarget(name: "SnapshotPreferences", path: "XCFrameworks/SnapshotPreferences.xcframework"),
+    ]
+  case "SnapshottingTests":
+    return [
+      .target(name: "SnapshottingTestsObjc", dependencies: [.product(name: "SimpleDebugger", package: "SimpleDebugger", condition: .when(platforms: [.iOS, .macOS, .macCatalyst]))]),
+      .target(name: "SnapshottingTests", dependencies: ["PreviewsSupport", "SnapshotSharedModels", "SnapshotPreviewsCore", "SnapshottingTestsObjc"]),
+      .binaryTarget(name: "PreviewsSupport", path: "XCFrameworks/PreviewsSupport.xcframework"),
+      .binaryTarget(name: "SnapshotSharedModels", path: "XCFrameworks/SnapshotSharedModels.xcframework"),
+      .binaryTarget(name: "SnapshotPreviewsCore", path: "XCFrameworks/SnapshotPreviewsCore.xcframework"),
+    ]
+  case "Snapshotting":
+    return [
+      .target(name: "Snapshotting", dependencies: ["SnapshottingSwift"]),
+      .target(name: "SnapshottingSwift", dependencies: ["PreviewsSupport", "SnapshotSharedModels", "SnapshotPreviewsCore", .product(name: "FlyingFox", package: "FlyingFox")]),
+      .binaryTarget(name: "PreviewsSupport", path: "XCFrameworks/PreviewsSupport.xcframework"),
+      .binaryTarget(name: "SnapshotSharedModels", path: "XCFrameworks/SnapshotSharedModels.xcframework"),
+      .binaryTarget(name: "SnapshotPreviewsCore", path: "XCFrameworks/SnapshotPreviewsCore.xcframework"),
+    ]
+  default:
+    fatalError("Set SNAPSHOT_PREVIEWS_XCFRAMEWORK_PRODUCT to the framework being built")
+  }
+}
+
+let package = Package(
+  name: product,
+  platforms: [.iOS(.v15), .macOS(.v12), .watchOS(.v9)],
+  products: [
+    .library(name: product, type: .dynamic, targets: [product]),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/swhitty/FlyingFox.git", exact: "0.16.0"),
+    .package(url: "https://github.com/EmergeTools/SimpleDebugger.git", exact: "1.0.0"),
+  ],
+  targets: selectedTargets(),
+  cxxLanguageStandard: .cxx11
+)

--- a/build.sh
+++ b/build.sh
@@ -96,16 +96,6 @@ copy_swift_module() {
     configuration="Release"
   fi
 
-  local source_module_path="$DERIVED_DATA_DIR/$framework/Build/Intermediates.noindex/ArchiveIntermediates/$framework/BuildProductsPath/$configuration/$framework.swiftmodule"
-  if [ ! -d "$source_module_path" ]; then
-    if requires_swift_module "$framework"; then
-      echo "Missing Swift module output for $framework at $source_module_path" >&2
-      exit 1
-    fi
-
-    return
-  fi
-
   local framework_path="$archive_path/Products/Library/Frameworks/$framework.framework"
   local modules_path="$framework_path/Modules"
 
@@ -115,6 +105,19 @@ copy_swift_module() {
       rm -r "$framework_path/Modules"
     fi
     ln -s "Versions/Current/Modules" "$framework_path/Modules"
+  fi
+
+  local source_module_path="$DERIVED_DATA_DIR/$framework/Build/Intermediates.noindex/ArchiveIntermediates/$framework/BuildProductsPath/$configuration/$framework.swiftmodule"
+  if [ ! -d "$source_module_path" ]; then
+    if requires_swift_module "$framework"; then
+      echo "Missing Swift module output for $framework at $source_module_path" >&2
+      exit 1
+    fi
+
+    if [ -d "$modules_path" ]; then
+      sanitize_swift_interfaces "$modules_path" "$framework"
+    fi
+    return
   fi
 
   mkdir -p "$modules_path"

--- a/build.sh
+++ b/build.sh
@@ -1,62 +1,193 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd -P)"
-PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+PROJECT_ROOT="$SCRIPT_DIR"
 
-PROJECT_BUILD_DIR="${PROJECT_BUILD_DIR:-"${PROJECT_ROOT}/build"}"
-XCODEBUILD_BUILD_DIR="$PROJECT_BUILD_DIR/xcodebuild"
-XCODEBUILD_DERIVED_DATA_PATH="$XCODEBUILD_BUILD_DIR/DerivedData"
+OUTPUT_DIR="$PROJECT_ROOT/XCFrameworks"
+PROJECT_BUILD_DIR="${PROJECT_BUILD_DIR:-"$PROJECT_ROOT/build"}"
+XCFRAMEWORK_BUILD_DIR="$PROJECT_BUILD_DIR/xcframeworks"
+TEMP_PACKAGE_DIR="$XCFRAMEWORK_BUILD_DIR/package"
+ARCHIVES_DIR="$XCFRAMEWORK_BUILD_DIR/archives"
+DERIVED_DATA_DIR="$XCFRAMEWORK_BUILD_DIR/DerivedData"
 
-build_framework() {
-    local sdk="$1"
-    local destination="$2"
-    local scheme="$3"
+FRAMEWORKS=(
+  SnapshotSharedModels
+  SnapshotPreviewsCore
+  SnapshotPreferences
+  PreviewGallery
+  SnapshottingTests
+  Snapshotting
+)
 
-    local XCODEBUILD_ARCHIVE_PATH="./$scheme-$sdk.xcarchive"
+SWIFT_MODULE_FRAMEWORKS=(
+  SnapshotSharedModels
+  SnapshotPreviewsCore
+  SnapshotPreferences
+  PreviewGallery
+  SnapshottingTests
+)
 
-    rm -rf "$XCODEBUILD_ARCHIVE_PATH"
+PLATFORMS=(
+  "iphoneos|generic/platform=iOS"
+  "iphonesimulator|generic/platform=iOS Simulator"
+  "macosx|generic/platform=macOS"
+  "watchos|generic/platform=watchOS"
+  "watchsimulator|generic/platform=watchOS Simulator"
+)
 
-    xcodebuild archive \
-        -scheme $scheme \
-        -archivePath $XCODEBUILD_ARCHIVE_PATH \
-        -derivedDataPath "$XCODEBUILD_DERIVED_DATA_PATH" \
-        -sdk "$sdk" \
-        -destination "$destination" \
-        BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
-        INSTALL_PATH='Library/Frameworks' \
-        OTHER_SWIFT_FLAGS=-no-verify-emitted-module-interface
+prepare_temp_package() {
+  local framework="$1"
 
-    FRAMEWORK_MODULES_PATH="$XCODEBUILD_ARCHIVE_PATH/Products/Library/Frameworks/$scheme.framework/Modules"
-    mkdir -p "$FRAMEWORK_MODULES_PATH"
-    cp -r \
-    "$XCODEBUILD_DERIVED_DATA_PATH/Build/Intermediates.noindex/ArchiveIntermediates/$scheme/BuildProductsPath/Release-$sdk/$scheme.swiftmodule" \
-    "$FRAMEWORK_MODULES_PATH/$scheme.swiftmodule"
-    # Delete private swiftinterface
-    rm -f "$FRAMEWORK_MODULES_PATH/$scheme.swiftmodule/*.private.swiftinterface"
-    find "$FRAMEWORK_MODULES_PATH/$scheme.swiftmodule" -type f -name "*.swiftinterface" | while read -r file; do
-      # Remove lines containing "NSInvocation"
-      sed -e '/NSInvocation/d' -e 's/XCTest\.//g' "$file" > temp && mv temp "$file"
-    done
+  if [ -d "$TEMP_PACKAGE_DIR" ]; then
+    rm -r "$TEMP_PACKAGE_DIR"
+  fi
 
+  mkdir -p "$TEMP_PACKAGE_DIR"
+  ln -s "$PROJECT_ROOT/Sources" "$TEMP_PACKAGE_DIR/Sources"
+  ln -s "$PROJECT_ROOT/XCFrameworks" "$TEMP_PACKAGE_DIR/XCFrameworks"
+  cp "$PROJECT_ROOT/XCFrameworkPackage.swift" "$TEMP_PACKAGE_DIR/Package.swift"
 }
 
-# Update the Package.swift to build the library as dynamic instead of static
-sed -i '' '/Replace this/ s/.*/type: .dynamic,/' Package.swift
+requires_swift_module() {
+  local framework="$1"
 
-# Build SnapshottingTests
-build_framework "iphonesimulator" "generic/platform=iOS Simulator" "SnapshottingTests"
-build_framework "iphoneos" "generic/platform=iOS" "SnapshottingTests"
+  for swift_module_framework in "${SWIFT_MODULE_FRAMEWORKS[@]}"; do
+    if [ "$swift_module_framework" = "$framework" ]; then
+      return 0
+    fi
+  done
 
-# Build PreviewGallery
-build_framework "iphonesimulator" "generic/platform=iOS Simulator" "PreviewGallery"
-build_framework "iphoneos" "generic/platform=iOS" "PreviewGallery"
+  return 1
+}
 
-echo "Builds completed successfully."
+build_framework_archive() {
+  local framework="$1"
+  local sdk="$2"
+  local destination="$3"
+  local archive_path="$ARCHIVES_DIR/$framework-$sdk.xcarchive"
 
-rm -rf "SnapshottingTests.xcframework"
-xcodebuild -create-xcframework -framework SnapshottingTests-iphonesimulator.xcarchive/Products/Library/Frameworks/SnapshottingTests.framework -framework SnapshottingTests-iphoneos.xcarchive/Products/Library/Frameworks/SnapshottingTests.framework -output SnapshottingTests.xcframework
+  if [ -d "$archive_path" ]; then
+    rm -r "$archive_path"
+  fi
 
-rm -rf "PreviewGallery.xcframework"
-xcodebuild -create-xcframework -framework PreviewGallery-iphonesimulator.xcarchive/Products/Library/Frameworks/PreviewGallery.framework -framework PreviewGallery-iphoneos.xcarchive/Products/Library/Frameworks/PreviewGallery.framework -output PreviewGallery.xcframework
+  SNAPSHOT_PREVIEWS_XCFRAMEWORK_PRODUCT="$framework" xcodebuild archive \
+    -scheme "$framework" \
+    -archivePath "$archive_path" \
+    -derivedDataPath "$DERIVED_DATA_DIR/$framework" \
+    -sdk "$sdk" \
+    -destination "$destination" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    INSTALL_PATH="Library/Frameworks" \
+    SKIP_INSTALL=NO \
+    OTHER_SWIFT_FLAGS="-no-verify-emitted-module-interface"
+
+  copy_swift_module "$framework" "$sdk" "$archive_path"
+}
+
+copy_swift_module() {
+  local framework="$1"
+  local sdk="$2"
+  local archive_path="$3"
+  local configuration="Release-$sdk"
+
+  if [ "$sdk" = "macosx" ]; then
+    configuration="Release"
+  fi
+
+  local source_module_path="$DERIVED_DATA_DIR/$framework/Build/Intermediates.noindex/ArchiveIntermediates/$framework/BuildProductsPath/$configuration/$framework.swiftmodule"
+  if [ ! -d "$source_module_path" ]; then
+    if requires_swift_module "$framework"; then
+      echo "Missing Swift module output for $framework at $source_module_path" >&2
+      exit 1
+    fi
+
+    return
+  fi
+
+  local framework_path="$archive_path/Products/Library/Frameworks/$framework.framework"
+  local modules_path="$framework_path/Modules"
+
+  if [ "$sdk" = "macosx" ] && [ -d "$framework_path/Versions/A" ]; then
+    modules_path="$framework_path/Versions/A/Modules"
+    if [ -e "$framework_path/Modules" ]; then
+      rm -r "$framework_path/Modules"
+    fi
+    ln -s "Versions/Current/Modules" "$framework_path/Modules"
+  fi
+
+  mkdir -p "$modules_path"
+  if [ -d "$modules_path/$framework.swiftmodule" ]; then
+    rm -r "$modules_path/$framework.swiftmodule"
+  fi
+  cp -r "$source_module_path" "$modules_path/$framework.swiftmodule"
+  sanitize_swift_interfaces "$modules_path" "$framework"
+}
+
+sanitize_swift_interfaces() {
+  local modules_path="$1"
+  local framework="$2"
+
+  find "$modules_path" -type f -name "*.private.swiftinterface" -delete
+  find "$modules_path" -type f -name "*.swiftinterface" | while read -r file; do
+    sed \
+      -e '/NSInvocation/d' \
+      -e 's/XCTest\.//g' \
+      -e "s/${framework}\.//g" \
+      "$file" > "$file.tmp"
+    mv "$file.tmp" "$file"
+  done
+}
+
+create_xcframework() {
+  local framework="$1"
+  local output_path="$OUTPUT_DIR/$framework.xcframework"
+  local args=()
+
+  for platform in "${PLATFORMS[@]}"; do
+    local sdk="${platform%%|*}"
+    args+=(
+      -framework
+      "$ARCHIVES_DIR/$framework-$sdk.xcarchive/Products/Library/Frameworks/$framework.framework"
+    )
+  done
+
+  if [ -d "$output_path" ]; then
+    rm -r "$output_path"
+  fi
+
+  xcodebuild -create-xcframework "${args[@]}" -output "$output_path"
+}
+
+copy_previews_support() {
+  local source_path="$PROJECT_ROOT/PreviewsSupport/PreviewsSupport.xcframework"
+  local output_path="$OUTPUT_DIR/PreviewsSupport.xcframework"
+
+  if [ -d "$output_path" ]; then
+    rm -r "$output_path"
+  fi
+  ditto "$source_path" "$output_path"
+}
+
+main() {
+  mkdir -p "$OUTPUT_DIR" "$ARCHIVES_DIR"
+  copy_previews_support
+
+  for framework in "${FRAMEWORKS[@]}"; do
+    prepare_temp_package "$framework"
+    pushd "$TEMP_PACKAGE_DIR" >/dev/null
+    for platform in "${PLATFORMS[@]}"; do
+      sdk="${platform%%|*}"
+      destination="${platform#*|}"
+      build_framework_archive "$framework" "$sdk" "$destination"
+    done
+    popd >/dev/null
+
+    create_xcframework "$framework"
+  done
+
+  echo "XCFrameworks written to $OUTPUT_DIR"
+}
+
+main "$@"


### PR DESCRIPTION
Adds XCFramework binary distribution support for SnapshotPreviews while keeping the standard Swift Package integration source-first.

The release build now produces the full manually consumable framework set under `XCFrameworks/`, packages those artifacts for GitHub releases, and includes a separate example project that integrates the generated frameworks without Swift Package Manager.

**Swift Package vs binary distribution**

`Package.swift` remains the public source-package manifest. SwiftPM is allowed to choose linkage for regular products, while `Snapshotting` stays explicitly dynamic because it is the inserted/runtime dylib product.

`XCFrameworkPackage.swift` is a build-only manifest used by `build.sh`. It forces the currently built product to dynamic for binary packaging and wires already-built SnapshotPreviews dependencies back in as binary targets, so shared support modules are dynamically linked instead of being repeatedly embedded into parent frameworks.

**Vended artifact layout**

Generated binary artifacts are written to `XCFrameworks/`:

- `SnapshotSharedModels.xcframework`
- `SnapshotPreviewsCore.xcframework`
- `SnapshotPreferences.xcframework`
- `PreviewGallery.xcframework`
- `SnapshottingTests.xcframework`
- `Snapshotting.xcframework`
- `PreviewsSupport.xcframework`

`PreviewsSupport` remains checked in at `PreviewsSupport/PreviewsSupport.xcframework` for SwiftPM usage. The distribution build copies it into `XCFrameworks/` so binary consumers and release assets use one artifact folder.

**Dynamic dependency model**

Manual XCFramework integration does not get SwiftPM dependency resolution automatically, so consumers must link and embed the documented framework closure for each target.

The generated frameworks keep shared SnapshotPreviews dependencies as dynamic framework dependencies. This avoids duplicating shared support modules across frameworks when multiple SnapshotPreviews products are loaded in the same process.

**Binary example project**

`Examples/DemoApp` remains the normal local Swift Package example.

`Examples/DemoApp-XCFrameworks` is the manual binary integration example. It shares source files from `../DemoApp/...`, links against `../../XCFrameworks/*.xcframework`, and includes a small wrapper script:

```bash
cd Examples/DemoApp-XCFrameworks
./generate-xcframeworks.sh
open DemoApp-XCFrameworks.xcodeproj
```

Shared demo source that depends on optional external packages uses `canImport`, so the Swift Package example can keep accessibility snapshot rendering while the XCFramework example builds without that external package.

**Manual integration matrix**

For an app target using per-preview rendering preferences:

- `SnapshotPreferences.xcframework`
- `SnapshotSharedModels.xcframework`

For an app target using the gallery UI:

- `PreviewGallery.xcframework`
- `SnapshotPreviewsCore.xcframework`
- `SnapshotPreferences.xcframework`
- `SnapshotSharedModels.xcframework`
- `PreviewsSupport.xcframework`

For an XCTest snapshot/layout target:

- `SnapshottingTests.xcframework`
- `SnapshotPreviewsCore.xcframework`
- `SnapshotSharedModels.xcframework`
- `PreviewsSupport.xcframework`

For the inserted-dylib/accessibility runtime flow, also include:

- `Snapshotting.xcframework`

Refs EME-1168
