### PR TITLE
test(snapshots): Demonstrate selective ModuleA snapshot upload [do not merge]

### DIFF
--- a/Examples/MultiModuleDemo/ModuleA/ModuleAViews.swift
+++ b/Examples/MultiModuleDemo/ModuleA/ModuleAViews.swift
@@ -22,7 +22,7 @@ public struct ModuleALabel: View {
 
   public var body: some View {
     Text(text)
-      .font(.headline)
+      .font(.title)
       .padding(.horizontal, 12)
       .padding(.vertical, 8)
       .background(.thinMaterial, in: Capsule())


### PR DESCRIPTION
> [!IMPORTANT]
> Do not merge this PR, it acts as an example of selective testing

Demonstrate selective snapshot uploads by changing previews in a single test-covered area.

This PR intentionally changes only `ModuleA` preview output. The snapshot workflow should therefore select only the ModuleA snapshot test case instead of rendering the full suite.

**Selective test selection**

Only files under `Examples/MultiModuleDemo/ModuleA` changed, so the workflow should run the ModuleA snapshot test shard and skip the ModuleB/ModuleC shard. This shows how source-path based selection limits snapshot generation to the smallest relevant test case set.

**Changed snapshot**

The ModuleA label now uses a larger title font. This should appear as a visual diff for the ModuleA label snapshots while unrelated ModuleB and ModuleC snapshots are not regenerated.

**Sentry UI**
<img width="1218" height="1193" alt="Screenshot 2026-06-08 at 19 26 55" src="https://github.com/user-attachments/assets/b7662453-06ea-4906-b666-3106473f41f1" />
