### PR TITLE
ci: Replace curl-pipe-bash with action-setup-cli for Sentry CLI setup

### DIFF
--- a/.github/workflows/ios_sentry_upload_snapshots.yml
+++ b/.github/workflows/ios_sentry_upload_snapshots.yml
@@ -337,7 +337,7 @@ jobs:
           echo "Total PNG images: $(find "${SNAPSHOT_UPLOAD_BASE_DIR}" -type f -name '*.png' | wc -l | tr -d ' ')"
 
       - name: Install sentry-cli
-        run: curl -sL https://sentry.io/get-cli/ | bash
+        uses: getsentry/action-setup-cli@70d7e587b84c2e78cf4d37cd33d7b74fb3729c1b # v1
 
       # Upload the rendered snapshot files. On pull requests,
       # --all-image-file-names-file points Sentry at the full manifest so it can


### PR DESCRIPTION
## Summary
- The "Install sentry-cli" step used `curl -sL https://sentry.io/get-cli/ | bash`, piping a remote install script directly into a shell.
- Replaced it with [`getsentry/action-setup-cli`](https://github.com/getsentry/action-setup-cli), which downloads the `sentry-cli` release asset for the runner's OS/arch and verifies its sha256 against the digest GitHub recorded for that asset via the Releases API, before adding it to `PATH`. Uses `gh` only, no `curl`.

## Test plan
- [x] Validated the workflow file parses correctly
- [ ] Verify the job still installs sentry-cli and uploads snapshots correctly on this PR

Fixes VULN-2368

🤖 Generated with [Claude Code](https://claude.com/claude-code)