### PR TITLE
Add `PreviewTrait.snapshotExcluded`

### DIFF
--- a/Sources/SnapshotPreferences/ExcludeTrait.swift
+++ b/Sources/SnapshotPreferences/ExcludeTrait.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+import SnapshotSharedModels
+
+@available(iOS 18.0, macOS 15.0, watchOS 11.0, tvOS 18.0, *)
+extension PreviewTrait where T == Preview.ViewTraits {
+    public static func snapshotExcluded(_ excluded: Bool) -> Self {
+        .modifier(excluded ? SnapshotInclusionMode.excluded : .automatic)
+    }
+
+    public static var snapshotExcluded: Self {
+        .snapshotExcluded(true)
+    }
+}
+
+extension SnapshotInclusionMode: @retroactive PreviewModifier {
+    public func body(content: Content, context: Void) -> some View {
+        content
+    }
+}

--- a/Sources/SnapshotPreviewsCore/SnapshotPreviewsCore.swift
+++ b/Sources/SnapshotPreviewsCore/SnapshotPreviewsCore.swift
@@ -9,6 +9,7 @@ public struct Preview: Identifiable {
     displayName = preview.displayName
     device = preview.device
     layout = preview.layout
+    _modifiers = []
     _view = {
       ViewSelectorTree(SnapshotViewModel(index: preview.id)) {
         P.previews
@@ -26,10 +27,14 @@ public struct Preview: Identifiable {
     let preview = Mirror(reflecting: preview)
     let traits = preview.descendant("traits")! as! [Any]
     var layout = PreviewLayout.device
+    var modifiers: [Any] = []
     for t in traits {
       if let value = Mirror(reflecting: t).descendant("value") {
         if let value = value as? PreviewLayout {
           layout = value
+        } else if #available(iOS 18.0, macOS 15.0, watchOS 11.0, tvOS 18.0, *),
+               let traitModifiers = value as? [any PreviewModifier] {
+          modifiers += traitModifiers
         } else if String(describing: value).hasSuffix(".portraitUpsideDown") {
           orientation = .portraitUpsideDown
         } else if String(describing: value).hasSuffix(".landscapeLeft") {
@@ -39,6 +44,7 @@ public struct Preview: Identifiable {
         }
       }
     }
+    self._modifiers = modifiers
     self.orientation = orientation
     self.layout = layout
     displayName = preview.descendant("displayName") as? String
@@ -82,6 +88,14 @@ public struct Preview: Identifiable {
   public let index: Int
   public let device: PreviewDevice?
   public let layout: PreviewLayout
+
+  // we can't store `[any PreviewModifier]` because it's unavailable before iOS 18 et al
+  private let _modifiers: [Any]
+  @available(iOS 18.0, macOS 15.0, watchOS 11.0, tvOS 18.0, *)
+  public var modifiers: [any PreviewModifier] {
+    _modifiers as? [any PreviewModifier] ?? []
+  }
+
   private let _view: @MainActor () -> any View
   @MainActor public func view() -> any View {
     _view()

--- a/Sources/SnapshotSharedModels/SnapshotInclusionMode.swift
+++ b/Sources/SnapshotSharedModels/SnapshotInclusionMode.swift
@@ -1,0 +1,4 @@
+public enum SnapshotInclusionMode: Sendable {
+    case excluded
+    case automatic
+}

--- a/Sources/SnapshottingTests/PreviewLayoutTest.swift
+++ b/Sources/SnapshottingTests/PreviewLayoutTest.swift
@@ -60,6 +60,7 @@ open class PreviewLayoutTest: PreviewBaseTest, PreviewFilters {
       includedModules: Self.snapshotPreviewModules(),
       excludedModules: Self.excludedSnapshotPreviewModules()
     )
+    .filter(SnapshotPreviewInclusionFilter.shouldInclude)
     return previews.map { DiscoveredPreview.from(previewType: $0) }
   }
 

--- a/Sources/SnapshottingTests/SnapshotPreviewInclusionFilter.swift
+++ b/Sources/SnapshottingTests/SnapshotPreviewInclusionFilter.swift
@@ -1,0 +1,10 @@
+@_implementationOnly import SnapshotPreviewsCore
+import SnapshotSharedModels
+
+enum SnapshotPreviewInclusionFilter {
+  static func shouldInclude(preview: PreviewType) -> Bool {
+    guard #available(iOS 18.0, macOS 15.0, watchOS 11.0, tvOS 18.0, *) else { return true }
+    guard preview.previews.count == 1 else { return true }
+    return !preview.previews[0].modifiers.contains { ($0 as? SnapshotInclusionMode) == .excluded }
+  }
+}

--- a/Sources/SnapshottingTests/SnapshotTest.swift
+++ b/Sources/SnapshottingTests/SnapshotTest.swift
@@ -242,6 +242,8 @@ open class SnapshotTest: PreviewBaseTest, PreviewFilters {
       includedModules: Self.snapshotPreviewModules(),
       excludedModules: Self.excludedSnapshotPreviewModules()
     )
+    .filter(SnapshotPreviewInclusionFilter.shouldInclude)
+
     fileNameResolver = FileNameResolver(previews: previews)
 
     if let allSnapshotImageNamesWriter {


### PR DESCRIPTION
This PR makes it possible to mark (iOS 18, macOS 15+) previews as `.snapshotExcluded`, which makes it so they're automatically excluded from the snapshot test suite.

```swift
#Preview(traits: .snapshotExcluded) {
  MyView()
}
```

More broadly, this sets up infrastructure to extract [`PreviewModifier`](https://developer.apple.com/documentation/swiftui/previewmodifier)s declared on a preview (but doesn't actually apply them for now). A `View.snapshotExcluded()` modifier would be insufficient because that would require rendering the preview to extract the preference, whereas we often want to exclude it _without_ rendering.

It might also be useful to declare other `PreviewModifier`s in the future, both for syntactic sugar as well as for other cases where one needs metadata before rendering the view.